### PR TITLE
Use predefined launchEnvironment in addition to tunnel-specific params

### DIFF
--- a/Pod/Client/SBTUITunneledApplication.m
+++ b/Pod/Client/SBTUITunneledApplication.m
@@ -163,10 +163,21 @@ static NSString *ipAddress(NSNetService *service)
         [launchArguments addObject:SBTUITunneledApplicationLaunchOptionHasStartupCommands];
         self.launchArguments = launchArguments;
     }
-    
-    self.launchEnvironment = @{SBTUITunneledApplicationLaunchEnvironmentBonjourNameKey: self.bonjourName,
-                               SBTUITunneledApplicationLaunchEnvironmentRemotePortKey: [@(_remotePort) stringValue]};
-    
+
+    NSMutableDictionary<NSString *, NSString *> *launchEnvironment = [[NSMutableDictionary alloc] init];
+    if (self.launchEnvironment) {
+        // Add any previously defined entries in launchEnvironment
+        [launchEnvironment addEntriesFromDictionary:self.launchEnvironment];
+    }
+
+    // Add tunnel-specific entries to launchEnvironment
+    NSDictionary<NSString *, NSString *> *tunnelLaunchEnvironment = @{
+                            SBTUITunneledApplicationLaunchEnvironmentBonjourNameKey: self.bonjourName,
+                            SBTUITunneledApplicationLaunchEnvironmentRemotePortKey: [@(_remotePort) stringValue]
+                            };
+    [launchEnvironment addEntriesFromDictionary:tunnelLaunchEnvironment];
+    self.launchEnvironment = [launchEnvironment copy];
+
     [self.bonjourBrowser searchForServicesOfType:@"_http._tcp" inDomain:@""];
     
     __block BOOL startupBlockCompleted = NO;


### PR DESCRIPTION
It would be nice to be able to use other launchEnvironment parameters that were set on the XCUIApplication before launching.

Tested locally. Before this change I was not able to get my launchEnvironment parameters that I used for my tests before setting up SBTUITestTunnel. After the changes, I get my parameters and am still able to connect to the server from the client.

PS: Cool project! Just getting started trying it out, but seems really useful so far.