### PR TITLE
Check if queryString is not nil before passing it to regex matching.

### DIFF
--- a/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
+++ b/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
@@ -45,10 +45,11 @@
             queryString = components.query ?: @"";
         }
         
-        NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:match.query options:NSRegularExpressionCaseInsensitive error:nil];
-        NSUInteger regexMatches = [regex numberOfMatchesInString:queryString options:0 range:NSMakeRange(0, queryString.length)];
-        
-        matchesQuery = regexMatches > 0;
+        if (queryString) {
+            NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:match.query options:NSRegularExpressionCaseInsensitive error:nil];
+            NSUInteger regexMatches = [regex numberOfMatchesInString:queryString options:0 range:NSMakeRange(0, queryString.length)];
+            matchesQuery = regexMatches > 0;
+        }
     }
 
     BOOL matchesMethod = YES;


### PR DESCRIPTION
The “numberOfMatchesInString:options:range:” method crashes if nil is passed as the string parameter.

This could happen if the requst is a PUT/POST and the [NSString initWithData:encoding:] fails for some reason (according to NSString docs “ Returns nil if the initialization fails for some reason (for example if data does not represent valid data for encoding”).