### PR TITLE
Fix throttle test failure.

### DIFF
--- a/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
+++ b/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
@@ -31,7 +31,7 @@ class ThrottleTests: XCTestCase {
     }
     
     func testThrottle() {
-        app.throttleRequests(matching: SBTRequestMatch.url("httpbin.org"), responseTime: 0.0)
+        app.throttleRequests(matching: SBTRequestMatch.url("httpbin.org"), responseTime: 5.0)
         
         app.cells["executeDataTaskRequest"].tap()
         let start = Date()


### PR DESCRIPTION
Test was failing with an internal consistency exception:

'Prefix can't be nil!'

due to 0 delay on the throttle. The identifier generation does not
consider rules with 0 delays to be throttles.