### PR TITLE
Do not remove stub multiple times when same request is proxied

### DIFF
--- a/Example/SBTUITestTunnel_Tests/MonitorTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MonitorTests.swift
@@ -120,6 +120,23 @@ class MonitorTests: XCTestCase {
         app.stubRequestsRemoveAll()
         app.monitorRequestRemoveAll()
     }
+    
+    func testMonitorAndStubWithRemoveAfterTwoIterations() {
+        app.stubRequests(matching: SBTRequestMatch.url("httpbin.org"), returnJsonDictionary: ["stubbed": 1], returnCode: 200, responseTime: 0.0, removeAfterIterations: 2)
+        app.monitorRequests(matching: SBTRequestMatch.url("httpbin.org"))
+        
+        app.cells["executeDataTaskRequest"].tap()
+        XCTAssert(isNetworkResultStubbed())
+        
+        app.cells["executeDataTaskRequest"].tap()
+        XCTAssert(isNetworkResultStubbed())
+        
+        let requests = app.monitoredRequestsFlushAll()
+        XCTAssertEqual(requests.count, 2)
+        
+        app.stubRequestsRemoveAll()
+        app.monitorRequestRemoveAll()
+    }
  
     func testMonitorAndThrottle() {
         app.monitorRequests(matching: SBTRequestMatch.url("httpbin.org"))

--- a/Pod/Server/SBTProxyURLProtocol.m
+++ b/Pod/Server/SBTProxyURLProtocol.m
@@ -244,10 +244,12 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             // check if the request is also proxied, we might need to manually invoke the block here
             if (proxyRule) {
                 for (NSDictionary *matchingRule in matchingRules) {
-                    SBTProxyResponseBlock block = matchingRule[SBTProxyURLProtocolBlockKey];
-                    
-                    if (![block isEqual:[NSNull null]] && block != nil) {
-                        block(request, request, (NSHTTPURLResponse *)response, stubResponse.data, stubbingResponseTime);
+                    if (!matchingRule[SBTProxyURLProtocolStubResponse]) {
+                        SBTProxyResponseBlock block = matchingRule[SBTProxyURLProtocolBlockKey];
+                        
+                        if (![block isEqual:[NSNull null]] && block != nil) {
+                            block(request, request, (NSHTTPURLResponse *)response, stubResponse.data, stubbingResponseTime);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
As reviewed together with @tcamin, in case the same request was both stubbed and proxied at the same time the `removeAfterIterations` counter was decreased by two instead of one at each request, causing the stub to be removed earlier than expected.