### PR TITLE
Fix SBTUITest crashing on Device

### DIFF
--- a/Pod/Server/SBTUITestTunnelServer.m
+++ b/Pod/Server/SBTUITestTunnelServer.m
@@ -208,7 +208,7 @@ description:(desc), ##__VA_ARGS__]; \
 
 - (NSString *)commandQuit:(GCDWebServerRequest *)tunnelRequest
 {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
     exit(0);
 #endif
     return @"YES";

--- a/Pod/Server/SBTUITestTunnelServer.m
+++ b/Pod/Server/SBTUITestTunnelServer.m
@@ -208,7 +208,9 @@ description:(desc), ##__VA_ARGS__]; \
 
 - (NSString *)commandQuit:(GCDWebServerRequest *)tunnelRequest
 {
+#if TARGET_IPHONE_SIMULATOR
     exit(0);
+#endif
     return @"YES";
 }
 


### PR DESCRIPTION
While running SBT on a real device, the app would crash on tear down with the update it disables exit status on a real device