### PR TITLE
Change request/response json return type

### DIFF
--- a/Pod/Common/SBTMonitoredNetworkRequest.h
+++ b/Pod/Common/SBTMonitoredNetworkRequest.h
@@ -29,10 +29,10 @@
 @interface SBTMonitoredNetworkRequest : NSObject<NSCoding>
 
 - (nullable NSString *)responseString;
-- (nullable NSDictionary<NSString *, id> *)responseJSON;
+- (nullable id)responseJSON;
 
 - (nullable NSString *)requestString;
-- (nullable NSDictionary<NSString *, id> *)requestJSON;
+- (nullable id)requestJSON;
 
 - (BOOL)matches:(nonnull SBTRequestMatch *)match;
 

--- a/Pod/Common/SBTMonitoredNetworkRequest.m
+++ b/Pod/Common/SBTMonitoredNetworkRequest.m
@@ -97,10 +97,10 @@
     return ret;
 }
 
-- (NSDictionary<NSString *, id> *)responseJSON
+- (id)responseJSON
 {
     NSError *error = nil;
-    NSDictionary *ret = [NSJSONSerialization JSONObjectWithData:self.responseData options:NSJSONReadingMutableContainers error:&error];
+    id ret = [NSJSONSerialization JSONObjectWithData:self.responseData options:NSJSONReadingMutableContainers error:&error];
     
     return (ret && !error) ? ret : nil;
 }
@@ -116,10 +116,10 @@
     return ret;
 }
 
-- (NSDictionary<NSString *, id> *)requestJSON
+- (id)requestJSON
 {
     NSError *error = nil;
-    NSDictionary *ret = [NSJSONSerialization JSONObjectWithData:self.originalRequest.HTTPBody options:NSJSONReadingMutableContainers error:&error];
+    id ret = [NSJSONSerialization JSONObjectWithData:self.originalRequest.HTTPBody options:NSJSONReadingMutableContainers error:&error];
     
     return (ret && !error) ? ret : nil;
 }


### PR DESCRIPTION
The parsed JSON was cast to Dictionary, this caused crashes at call site when data
actually represented other data types (such as Arrays)