### PR TITLE
Add http body to SBTRequestMatch

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -53,6 +53,10 @@ The `query` parameter found in different `SBTRequestMatch` initializers is an ar
 
 In a kind of unconventional syntax you can prefix the regex with an exclamation mark `!` to specify that the request must not match that specific regex, see the following examples.
 
+### Body parameter
+
+The `body` parameter allow to match the request against its HTTP Body. As for the `query` parameter, the passed value is used as a regex which is evaluated on the request HTTP Body and the exlamation mark `!` can be used to specify an "inverted match" (i.e. that the HTTP Body should NOT match the provided `body` pattern).
+
 ### Examples
 
 The regex in `GET` and `DELETE` requests will match the entire URL including query parameters.
@@ -81,6 +85,11 @@ You can additionally specify that the query should not contain something by pref
 
 This will match if the query contains `param1=val1` AND `param2=val2` AND NOT `param3=val3`
 
+The `body` parameter can be used to match HTTP Body and also supports `!` to specify "inverted matches":
+	
+	let sr = SBTRequestMatch(url: "myhost.com", query: [], method: "POST", body: "SomeBodyContent")
+	let sr = SBTRequestMatch(url: "myhost.com", query: [], method: "POST", body: "!UnwantedBodyContent")
+    
 Finally you can limit a specific HTTP method by specifying it in the `method` parameter.
 
     // will match GET request only

--- a/Example/SBTUITestTunnel_Tests/MatchRequestTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MatchRequestTests.swift
@@ -81,6 +81,18 @@ class MatchRequestTests: XCTestCase {
         XCTAssert(request.isStubbed(result))
     }
     
+    func testPostWithBodyInverted() {
+        let requestMatchInverted = SBTRequestMatch(url: "httpbin.org", query: [], method: "POST", body: "!QueryName")
+        app.stubRequests(matching: requestMatchInverted, response: SBTStubResponse(response: ["stubbed": 1]))
+        
+        let containingBodyMatch = request.dataTaskNetwork(urlString: "http://httpbin.org", httpMethod: "POST", httpBody: "query QueryName")
+        XCTAssertFalse(request.isStubbed(containingBodyMatch))
+        
+        
+        let notContainingBodyMatch = request.dataTaskNetwork(urlString: "http://httpbin.org", httpMethod: "POST", httpBody: "query AnotherQuery")
+        XCTAssert(request.isStubbed(notContainingBodyMatch))
+    }
+    
     func testMethodHonored() {
         app.stubRequests(matching: SBTRequestMatch(url: "httpbin.org/post", method:"POST"), response: SBTStubResponse(response: ["stubbed": 1]))
         let result = request.dataTaskNetwork(urlString: "http://httpbin.org/post", httpMethod: "POST", httpBody: "&param5=val5&param6=val6")

--- a/Example/SBTUITestTunnel_Tests/MatchRequestTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MatchRequestTests.swift
@@ -40,7 +40,7 @@ class MatchRequestTests: XCTestCase {
         let result2 = request.dataTaskNetwork(urlString: "http://httpbin.org/post", httpMethod: "POST", httpBody: "&param5=val5&param6=val6")
         XCTAssertFalse(request.isStubbed(result2))
     }
-
+    
     func testUrlWithQueryGetOnly() {
         app.stubRequests(matching: SBTRequestMatch(url: "httpbin.org", query: ["&param1=val1", "&param2=val2"], method:"GET"), response: SBTStubResponse(response: ["stubbed": 1]))
         let result = request.dataTaskNetwork(urlString: "http://httpbin.org/get?param1=val1&param2=val2")
@@ -71,6 +71,14 @@ class MatchRequestTests: XCTestCase {
         let result6 = request.dataTaskNetwork(urlString: "http://httpbin.org/get?param1=val1&param2=val2")
         XCTAssertFalse(request.isStubbed(result6))
         XCTAssert(app.stubRequestsRemoveAll())
+    }
+    
+    func testPostWithBody() {
+        let requestMatch = SBTRequestMatch(url: "httpbin.org", query: [], method: "POST", body: "QueryName")
+        app.stubRequests(matching: requestMatch, response: SBTStubResponse(response: ["stubbed": 1]))
+        
+        let result = request.dataTaskNetwork(urlString: "http://httpbin.org", httpMethod: "POST", httpBody: "query QueryName")
+        XCTAssert(request.isStubbed(result))
     }
     
     func testMethodHonored() {

--- a/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
+++ b/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
@@ -78,11 +78,15 @@
 
     BOOL matchesBody = YES;
     if (match.body) {
+        BOOL invertMatch = [match.body hasPrefix:@"!"];
+        // skip first char for inverted matches
+        NSString *pattern = [match.body substringFromIndex:invertMatch ? 1 : 0];
+        
         NSString *body = [[NSString alloc] initWithData:self.HTTPBody encoding: NSUTF8StringEncoding];
-        NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:match.body options:nil error:nil];
+        NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:pattern options:nil error:nil];
         if (body) {
             NSUInteger regexMatches = [regex numberOfMatchesInString:body options:0 range:NSMakeRange(0, body.length)];
-            matchesBody = regexMatches > 0;
+            matchesBody = invertMatch ? (regexMatches == 0) : (regexMatches > 0);
         }
     }
     

--- a/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
+++ b/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
@@ -76,7 +76,17 @@
         matchesMethod = [self.HTTPMethod isEqualToString:match.method];
     }
 
-    return matchesURL && matchesQuery && matchesMethod;
+    BOOL matchesBody = YES;
+    if (match.body) {
+        NSString *body = [[NSString alloc] initWithData:self.HTTPBody encoding: NSUTF8StringEncoding];
+        NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:match.body options:nil error:nil];
+        if (body) {
+            NSUInteger regexMatches = [regex numberOfMatchesInString:body options:0 range:NSMakeRange(0, body.length)];
+            matchesBody = regexMatches > 0;
+        }
+    }
+    
+    return matchesURL && matchesQuery && matchesMethod && matchesBody;
 }
 
 @end

--- a/Pod/Common/SBTRequestMatch.h
+++ b/Pod/Common/SBTRequestMatch.h
@@ -29,6 +29,7 @@
 @property (nullable, nonatomic, readonly) NSString *url;
 @property (nullable, nonatomic, readonly) NSArray<NSString *> *query;
 @property (nullable, nonatomic, readonly) NSString *method;
+@property (nullable, nonatomic, readonly) NSString *body;
 
 /**
     Note:
@@ -58,6 +59,16 @@
  *  @param method HTTP method
  */
 - (nonnull instancetype)initWithURL:(nonnull NSString *)url query:(nonnull NSArray<NSString *> *)query method:(nonnull NSString *)method;
+
+/**
+ *  Initializer
+ *
+ *  @param url a regex that is matched against the request url
+ *  @param query an array of a regex that are matched against the request query (params in GET and DELETE, body in POST and PUT). Instance will match if all regex are fulfilled. You can specify that a certain query should not match by prefixing it with an exclamation mark `!`
+ *  @param method HTTP method
+ *  @body a regex that is matched against the request body
+ */
+- (nonnull instancetype)initWithURL:(nonnull NSString *)url query:(nonnull NSArray<NSString *> *)query method:(nonnull NSString *)method body:(nonnull NSString *)body;
 
 /**
  *  Initializer

--- a/Pod/Common/SBTRequestMatch.m
+++ b/Pod/Common/SBTRequestMatch.m
@@ -29,6 +29,7 @@
 @property (nonatomic, strong) NSString *url;
 @property (nonatomic, strong) NSArray<NSString *> *query;
 @property (nonatomic, strong) NSString *method;
+@property (nonatomic, strong) NSString *body;
 
 @end
 
@@ -40,6 +41,7 @@
         self.url = [decoder decodeObjectForKey:NSStringFromSelector(@selector(url))];
         self.query = [decoder decodeObjectForKey:NSStringFromSelector(@selector(query))];
         self.method = [decoder decodeObjectForKey:NSStringFromSelector(@selector(method))];
+        self.body = [decoder decodeObjectForKey:NSStringFromSelector(@selector(body))];
     }
     
     return self;
@@ -50,11 +52,12 @@
     [encoder encodeObject:self.url forKey:NSStringFromSelector(@selector(url))];
     [encoder encodeObject:self.query forKey:NSStringFromSelector(@selector(query))];
     [encoder encodeObject:self.method forKey:NSStringFromSelector(@selector(method))];
+    [encoder encodeObject:self.body forKey:NSStringFromSelector(@selector(body))];
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"URL: %@\nQuery: %@\nMethod: %@", self.url ?: @"N/A", self.query ?: @"N/A", self.method ?: @"N/A"];
+    return [NSString stringWithFormat:@"URL: %@\nQuery: %@\nMethod: %@\nBody: %@", self.url ?: @"N/A", self.query ?: @"N/A", self.method ?: @"N/A", self.body ?: @"N/A"];
 }
 
 - (nonnull instancetype)initWithURL:(NSString *)url
@@ -77,6 +80,15 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
+
+- (nonnull instancetype)initWithURL:(NSString *)url query:(NSArray<NSString *> *)query method:(NSString *)method body:(NSString *)body
+{
+    if ((self = [self initWithURL:url query:query method:method])) {
+        _body = body;
+    }
+    
+    return self;
+}
 
 - (nonnull instancetype)initWithURL:(NSString *)url query:(NSArray<NSString *> *)query method:(NSString *)method
 {


### PR DESCRIPTION
This allow to specify a regex to match against HTTP Body for selecting specific HTTP requests.