### PR TITLE
Make enableUrlProtocolInWkWebview optional

### DIFF
--- a/Pod/Server/SBTUITestTunnelServer.h
+++ b/Pod/Server/SBTUITestTunnelServer.h
@@ -58,6 +58,12 @@
  */
 + (nonnull NSString *)performCommand:(nonnull NSString *)commandName params:(nonnull NSDictionary<NSString *, NSString *> *)params;
 
+/**
+ Will enable URL protocol in the WKWebView.
+ Note: Enabling this can cause unexpected behavior for async requests in JS
+ */
++ (void)enableUrlProtocolInWkWebview;
+
 @end
 
 #endif

--- a/Pod/Server/SBTUITestTunnelServer.m
+++ b/Pod/Server/SBTUITestTunnelServer.m
@@ -99,7 +99,6 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
         sharedInstance.launchSemaphore = dispatch_semaphore_create(0);
 
         [sharedInstance reset];
-        [sharedInstance enableUrlProtocolInWkWebview];
         
         [NSURLProtocol registerClass:[SBTProxyURLProtocol class]];
     });
@@ -1182,7 +1181,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
     [[self customCommands] removeAllObjects];
 }
 
-- (void)enableUrlProtocolInWkWebview
++ (void)enableUrlProtocolInWkWebview
 {
     Class cls = NSClassFromString(@"WKBrowsingContextController");
     SEL sel = NSSelectorFromString(@"registerSchemeForCustomProtocol:");


### PR DESCRIPTION
Greetings,

I have been experiencing issues with WKWebViews in my UI tests.
We currently have tests that assert basic functionality of fairly complex web views containing a large amount of asynchronous JS requests. EnableUrlProtocolInWkWebview caused the aforementioned requests to fail due to their request bodies being removed. 

The easiest solution for me is to remove the call to enableUrlProtocolInWkWebview when the SBTUITestTunnelServer shared instance is initialised. The method remains and can be called manually after take off if required.

Thanks.