### PR TITLE
Fix core location auth status stubbing

### DIFF
--- a/Example/SBTUITestTunnel.xcodeproj/project.pbxproj
+++ b/Example/SBTUITestTunnel.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6003F59A195388D20070C39A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F599195388D20070C39A /* main.m */; };
 		6003F59E195388D20070C39A /* SBTAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F59D195388D20070C39A /* SBTAppDelegate.m */; };
 		6003F5A9195388D20070C39A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5A8195388D20070C39A /* Images.xcassets */; };
+		746907E8240109970000ADC7 /* CoreLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746907E7240109970000ADC7 /* CoreLocationTests.swift */; };
 		7E9AB1A722AEEA16001205E9 /* NoSwizzlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9AB1A622AEEA16001205E9 /* NoSwizzlingTests.swift */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		8CB30A965F90DB278A9F5DEC /* Pods_SBTUITestTunnel_TestsNoSwizzling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75BC5D08325F7CD8FC97BF4C /* Pods_SBTUITestTunnel_TestsNoSwizzling.framework */; };
@@ -88,6 +89,7 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		7177B09786F764558E92133F /* Pods-SBTUITestTunnel_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SBTUITestTunnel_Example.debug.xcconfig"; path = "Target Support Files/Pods-SBTUITestTunnel_Example/Pods-SBTUITestTunnel_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		7255D52519AE2B772452E63C /* Pods-SBTUITestTunnel_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SBTUITestTunnel_Tests.release.xcconfig"; path = "Target Support Files/Pods-SBTUITestTunnel_Tests/Pods-SBTUITestTunnel_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		746907E7240109970000ADC7 /* CoreLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocationTests.swift; sourceTree = "<group>"; };
 		75BC5D08325F7CD8FC97BF4C /* Pods_SBTUITestTunnel_TestsNoSwizzling.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SBTUITestTunnel_TestsNoSwizzling.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E9AB19C22AEE9DB001205E9 /* SBTUITestTunnel_TestsNoSwizzling.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SBTUITestTunnel_TestsNoSwizzling.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E9AB1A022AEE9DB001205E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				C3E3DFD91D8A78B5003D6BB2 /* DownloadUploadTests.swift */,
 				C3F380211D8FCACA002CDE17 /* ThrottleTest.swift */,
 				C30FD8E22029EED50054EA5C /* CookiesTest.swift */,
+				746907E7240109970000ADC7 /* CoreLocationTests.swift */,
 				C3E3DFD51D8A0082003D6BB2 /* MiscellaneousTests.swift */,
 				C363E5F520502B9F00DFCEB1 /* test_file.json */,
 				C39B79FC1CB41C3A000C8B0D /* Info.plist */,
@@ -594,6 +597,7 @@
 				FC5F178223A8D2C2003BBCA1 /* UnusedStubsPeekAll.swift in Sources */,
 				C3763A082332505700C0FAF5 /* SBTUITestTunnelServer+Extension.swift in Sources */,
 				C3881A971FED847C00EB6579 /* MiscellaneousTests.swift in Sources */,
+				746907E8240109970000ADC7 /* CoreLocationTests.swift in Sources */,
 				C3881A931FED847C00EB6579 /* UserDefaultsTests.swift in Sources */,
 				C3E3DFE01D8ECA9A003D6BB2 /* MonitorTests.swift in Sources */,
 				C3881A941FED847C00EB6579 /* StubTests.swift in Sources */,

--- a/Example/SBTUITestTunnel/SBTAppDelegate.m
+++ b/Example/SBTUITestTunnel/SBTAppDelegate.m
@@ -18,6 +18,7 @@
 
 #if DEBUG
     @import SBTUITestTunnelServer;
+    @import CoreLocation;
 #endif
 
 @implementation SBTAppDelegate
@@ -45,6 +46,10 @@
 
                 return @"123";
             }];
+            [SBTUITestTunnelServer registerCustomCommandNamed:@"myCustomCommandReturnCLAuthStatus" block:^NSObject *(NSObject *object) {
+                return [@([CLLocationManager authorizationStatus]) stringValue];
+            }];
+
 
             [SBTUITestTunnelServer takeOffCompleted:YES];
         }

--- a/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
@@ -1,0 +1,43 @@
+//
+//  CoreLocationTests.swift
+//  SBTUITestTunnel_Tests
+//
+//  Created by Egor Komarov on 22.02.2020.
+//  Copyright © 2020 Tomas Camin. All rights reserved.
+//
+
+import Foundation
+import SBTUITestTunnelClient
+import XCTest
+
+class CoreLocationTests: XCTestCase {
+
+    func testCoreLocationStubAuthorizationStatus() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+
+        app.coreLocationStubAuthorizationStatus(.notDetermined)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .notDetermined)
+
+        app.coreLocationStubAuthorizationStatus(.denied)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .denied)
+        
+        app.coreLocationStubAuthorizationStatus(.restricted)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .restricted)
+
+        app.coreLocationStubAuthorizationStatus(.authorizedWhenInUse)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedWhenInUse)
+
+        app.coreLocationStubAuthorizationStatus(.authorizedAlways)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+    }
+
+    
+    private func getStubbedCoreLocationAuthorizationStatus() -> CLAuthorizationStatus {
+        let statusString = app.performCustomCommandNamed("myCustomCommandReturnCLAuthStatus", object: nil) as! String
+        return CLAuthorizationStatus(rawValue: Int32(statusString)!)!
+    }
+
+}

--- a/Pod/Server/Private/CLLocationManager+Swizzles.h
+++ b/Pod/Server/Private/CLLocationManager+Swizzles.h
@@ -30,8 +30,8 @@
 
 @interface CLLocationManager (Swizzles)
 
-+ (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable
-                      authorizationStatus:(NSString *)autorizationStatus;
++ (void)setStubbedAuthorizationStatus:(NSString *)autorizationStatus;
++ (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable;
 + (void)removeSwizzles;
 
 - (id<CLLocationManagerDelegate>)stubbedDelegate;

--- a/Pod/Server/Private/CLLocationManager+Swizzles.m
+++ b/Pod/Server/Private/CLLocationManager+Swizzles.m
@@ -106,10 +106,14 @@ static NSString *_serviceStatus;
     return [_instanceHashTable objectForKey:self];
 }
 
-+ (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable authorizationStatus:(NSString *)autorizationStatus
++ (void)setStubbedAuthorizationStatus:(NSString *)autorizationStatus
+{
+    _autorizationStatus = autorizationStatus;
+}
+
++ (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable
 {
     _instanceHashTable = hashTable;
-    _autorizationStatus = autorizationStatus;
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/Pod/Server/SBTUITestTunnelServer.m
+++ b/Pod/Server/SBTUITestTunnelServer.m
@@ -86,7 +86,6 @@ void repeating_dispatch_after(int64_t delay, dispatch_queue_t queue, BOOL (^bloc
 @property (nonatomic, strong) dispatch_semaphore_t launchSemaphore;
 
 @property (nonatomic, strong) NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>> *coreLocationActiveManagers;
-@property (nonatomic, strong) NSMutableString *coreLocationStubbedAuthorizationStatus;
 @property (nonatomic, strong) NSMutableString *coreLocationStubbedServiceStatus;
 @property (nonatomic, strong) NSMutableString *notificationCenterStubbedAuthorizationStatus;
 
@@ -1019,7 +1018,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 {
     BOOL stubSystemLocation = [tunnelRequest.parameters[SBTUITunnelObjectValueKey] isEqualToString:@"YES"];
     if (stubSystemLocation) {
-        [CLLocationManager loadSwizzlesWithInstanceHashTable:self.coreLocationActiveManagers authorizationStatus:self.coreLocationStubbedAuthorizationStatus];
+        [CLLocationManager loadSwizzlesWithInstanceHashTable:self.coreLocationActiveManagers];
     } else {
         [CLLocationManager removeSwizzles];
     }
@@ -1031,7 +1030,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 {
     NSString *authorizationStatus = tunnelRequest.parameters[SBTUITunnelObjectValueKey];
     
-    [self.coreLocationStubbedAuthorizationStatus setString:authorizationStatus];
+    [CLLocationManager setStubbedAuthorizationStatus:authorizationStatus];
     for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
         [locationManager.stubbedDelegate locationManager:locationManager didChangeAuthorizationStatus:authorizationStatus.intValue];
     }


### PR DESCRIPTION
`SBTUITunneledApplication.coreLocationStubAuthorizationStatus(...)` doesn't change what `CLLocationManager.authorizationStatus()` would return to the caller in the tested application.
`SBTUITestTunnelServer.coreLocationStubbedAuthorizationStatus` isn't initialized anywhere, setting its string in `- commandCoreLocationStubAuthorizationStatus:` has no effect. Also `- commandCoreLocationStubAuthorizationStatus:` never updates `_autorizationStatus` variable in `CLLocationManager+Swizzles.m`, so `CLLocationManager.authorizationStatus()` keeps returning default `.authorizedAlways` status regardless of a stubbed value.

PR removes `SBTUITestTunnelServer.coreLocationStubbedAuthorizationStatus` attribute. `- commandCoreLocationStubAuthorizationStatus:` updates `_autorizationStatus` right away.
Test which covers related functionality added.