### PR TITLE
Optimize request matching performance.

### DIFF
--- a/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
+++ b/Pod/Common/NSURLRequest+SBTUITestTunnelMatch.m
@@ -30,6 +30,12 @@
 
 - (BOOL)matches:(SBTRequestMatch *)match
 {
+    BOOL matchesMethod = YES;
+    if (match.method) {
+        matchesMethod = [self.HTTPMethod isEqualToString:match.method];
+        if (!matchesMethod) return NO;
+    }
+
     BOOL matchesURL = YES;
     if (match.url) {
         NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:match.url options:NSRegularExpressionCaseInsensitive error:nil];
@@ -39,6 +45,7 @@
             
             matchesURL = regexMatches > 0;
         }
+        if (!matchesURL) return NO;
     }
 
     BOOL matchesQuery = YES;
@@ -63,11 +70,7 @@
                 }
             }
         }
-    }
-
-    BOOL matchesMethod = YES;
-    if (match.method) {
-        matchesMethod = [self.HTTPMethod isEqualToString:match.method];
+        if (!matchesQuery) return NO;
     }
 
     BOOL matchesBody = YES;
@@ -82,6 +85,7 @@
             NSUInteger regexMatches = [regex numberOfMatchesInString:body options:0 range:NSMakeRange(0, body.length)];
             matchesBody = invertMatch ? (regexMatches == 0) : (regexMatches > 0);
         }
+        if (!matchesBody) return NO;
     }
         
     return matchesURL && matchesQuery && matchesMethod && matchesBody;


### PR DESCRIPTION
## Problem

Request matching, especially when using a `body` match, can be expensive. When there are multiple requests executing concurrently, this method is in a hot path, and can cause lock contention with the `@synchronized` code elsewhere in the library.

## Solution

Short-circuit the matching logic when any part fails to match.

In my testing, this eliminates the lock contention when using a body matcher.