### PR TITLE
Use a random identifier for matching rules

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -185,6 +185,29 @@ app.stubRequests(matching: SBTRequestMatch.url("google.com"), response: response
 
 The URLSession will fail with an `Error` according to the specified `errorCode`.
 
+#### Multiple stubs for same request match 
+
+It's possible to specify multiple stubs for the same request match: stubs are evaluated in LIFO order (the latest added stub will be used). Adding multiple stubs for the same request match can be very powerful when combined with `activeIterations`; we can specify in advance a "series" of stubs we want to use which will be applied in order and removed when their `activeIterations` value reaches zero. This allows to test some cases where multple network calls are peformed subsequently and is not possibile to "manually" substitute a stub for the same network call. 
+
+For example we can test that, when receiving an authentication error, a client performs a credentials refresh and retries the original network request.
+
+```swift
+app.stubRequests(matching: requestMatchForAuthenticatedCall,
+                 response: successfulResponse)
+
+// Note that we remove authentication error response after one iteration
+app.stubRequests(matching: requestMatchForAuthenticatedCall,
+                 response: authenticationErrorResponse(activeIterations: 1))
+ 
+app.monitorRequests(matching: credentialsRefreshCall, during: {
+   // action to perform authenticated call
+})
+    
+verifyAuthenticatedCallSuccess()
+
+```
+
+
 ### Upload / Download items
 
 #### Upload

--- a/Example/SBTUITestTunnel_Tests/CookiesTest.swift
+++ b/Example/SBTUITestTunnel_Tests/CookiesTest.swift
@@ -62,6 +62,23 @@ class CookiesTest: XCTestCase {
         XCTAssert(app.blockCookiesRequestsRemove(withId: requestId))
         XCTAssertEqual(countCookies(), 1)
     }
+
+    func testMultipleBlockCookiesForSameRequestMatch() {
+        HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
+        _ = request.dataTaskNetwork(urlString: "http://httpbin.org/cookies/set?name=value") // set a random cookie
+                
+        XCTContext.runActivity(named: "When adding multiple block cookies for the same requests match") { _ in
+            let requestMatch = SBTRequestMatch(url: "httpbin.org")
+            app.blockCookiesInRequests(matching: requestMatch, activeIterations: 1)
+            app.blockCookiesInRequests(matching: requestMatch, activeIterations: 1)
+        }
+        
+        XCTContext.runActivity(named: "They are removed when finishing active iterations") { _ in
+            XCTAssertEqual(countCookies(), 0)
+            XCTAssertEqual(countCookies(), 0)
+            XCTAssertEqual(countCookies(), 1)
+        }
+    }
 }
 
 extension CookiesTest {

--- a/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
+++ b/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
@@ -103,8 +103,8 @@ class ThrottleTests: XCTestCase {
     func testMultipleThrottleForSameRequestMatch() throws {
         let requestMatch = SBTRequestMatch(url: "httpbin.org")
         
-        let delay1 = 2.0
-        let delay2 = 4.0
+        let delay1 = 7.0
+        let delay2 = 1.0
         _ = app.throttleRequests(matching: requestMatch, responseTime: delay1)
         let throttle2Id = try XCTUnwrap(app.throttleRequests(matching: requestMatch, responseTime: delay2))
         

--- a/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
+++ b/Example/SBTUITestTunnel_Tests/ThrottleTest.swift
@@ -116,7 +116,7 @@ class ThrottleTests: XCTestCase {
         }
         
         XCTContext.runActivity(named: "After removing the second throttle rule, the first one is used.") { _ in
-            app.rewriteRequestsRemove(withId: throttle2Id)
+            app.throttleRequestRemove(withId: throttle2Id)
             let start = Date()
             _ = request.dataTaskNetwork(urlString: "http://httpbin.org/get?param1=val1&param2=val2")
             let delta = start.timeIntervalSinceNow

--- a/Pod/Common/SBTRequestMatch.swift
+++ b/Pod/Common/SBTRequestMatch.swift
@@ -103,11 +103,6 @@ public class SBTRequestMatch: NSObject, NSCoding, NSCopying {
         return copy
     }
     
-    @objc public func identifier() -> String {
-        var data = NSKeyedArchiver.archivedData(withRootObject: self)
-        return SHA1.hexString(from: &data)?.replacingOccurrences(of: " ", with: "-") ?? ""
-    }
-    
     @objc(matchesRequestHeaders:)
     public func matches(requestHeaders: [String: String]?) -> Bool {
         guard let requestHeaders = requestHeaders,

--- a/Pod/Server/Private/SBTProxyURLProtocol.h
+++ b/Pod/Server/Private/SBTProxyURLProtocol.h
@@ -66,8 +66,6 @@
 + (BOOL)cookieBlockRequestsRemoveWithId:(nonnull NSString *)reqId;
 + (void)cookieBlockRequestsRemoveAll;
 
-+ (nonnull NSString *)identifierForRule:(nonnull NSDictionary *)rule;
-
 @end
 
 #endif

--- a/Pod/Server/Private/SBTProxyURLProtocol.m
+++ b/Pod/Server/Private/SBTProxyURLProtocol.m
@@ -373,15 +373,15 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
         // Note that we only consider the first instance found for each rule type. We want to "skip" other instances which could be evaluated in future calls.
         if (matchingRule[SBTProxyURLProtocolStubResponse]) {
             if (stubRule == nil) {
-            stubRule = matchingRule;
+                stubRule = matchingRule;
             }
         } else if (matchingRule[SBTProxyURLProtocolRewriteResponse]) {
             if (rewriteRule == nil) {
-            rewriteRule = matchingRule;
+                rewriteRule = matchingRule;
             }
         } else if (matchingRule[SBTProxyURLProtocolBlockCookiesKey]) {
             if (cookieBlockRule == nil) {
-            cookieBlockRule = matchingRule;
+                cookieBlockRule = matchingRule;
             }
         } else {
             // we can have multiple matching rule here. For example if we throttle and monitor at the same time
@@ -462,7 +462,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             
             if (stubResponse.activeIterations > 0) {
                 if (--stubResponse.activeIterations == 0) {
-                    [SBTProxyURLProtocol stubRequestsRemoveWithId:stubRule[SBTProxyURLProtocolStubResponse]];
+                    [SBTProxyURLProtocol stubRequestsRemoveWithId:stubRule[SBTProxyURLProtocolMatchingRuleIdentifierKey]];
                 }
             }
         });
@@ -487,7 +487,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             NSInteger cookieBlockActiveIterations = [cookieBlockRule[SBTProxyURLProtocolBlockCookiesActiveIterationsKey] integerValue];
             
             if (--cookieBlockActiveIterations == 0) {
-                [SBTProxyURLProtocol cookieBlockRequestsRemoveWithId:cookieBlockRule[SBTProxyURLProtocolStubResponse]];
+                [SBTProxyURLProtocol cookieBlockRequestsRemoveWithId:cookieBlockRule[SBTProxyURLProtocolMatchingRuleIdentifierKey]];
             } else {
                 //cookieBlockRule[SBTProxyURLProtocolBlockCookiesActiveIterationsKey] = @(cookieBlockActiveIterations);
             }
@@ -573,7 +573,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
         }
         
         if (--rewrite.activeIterations == 0) {
-            [SBTProxyURLProtocol rewriteRequestsRemoveWithId:rewriteRule[SBTProxyURLProtocolStubResponse]];
+            [SBTProxyURLProtocol rewriteRequestsRemoveWithId:rewriteRule[SBTProxyURLProtocolMatchingRuleIdentifierKey]];
         }
     }
     
@@ -658,7 +658,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
         
         if (stubResponse.activeIterations > 0) {
             if (--stubResponse.activeIterations == 0) {
-                [SBTProxyURLProtocol stubRequestsRemoveWithId:headersStubRequest[SBTProxyURLProtocolStubResponse]];
+                [SBTProxyURLProtocol stubRequestsRemoveWithId:headersStubRequest[SBTProxyURLProtocolMatchingRuleIdentifierKey]];
             }
         }
         

--- a/Pod/Server/Private/SBTProxyURLProtocol.m
+++ b/Pod/Server/Private/SBTProxyURLProtocol.m
@@ -81,8 +81,8 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
 
 + (NSString *)throttleRequestsMatching:(SBTRequestMatch *)match delayResponse:(NSTimeInterval)delayResponseTime;
 {
-    NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match,
-                                            SBTProxyURLProtocolDelayResponseTimeKey: @(delayResponseTime)}];
+    NSDictionary *rule = [self makeRuleWithAttributes:@{SBTProxyURLProtocolMatchingRuleKey: match,
+                                                        SBTProxyURLProtocolDelayResponseTimeKey: @(delayResponseTime)}];
     
     @synchronized (self.sharedInstance) {
         [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
@@ -127,7 +127,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
 
 + (NSString *)monitorRequestsMatching:(SBTRequestMatch *)match;
 {
-    NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match}];
+    NSDictionary *rule = [self makeRuleWithAttributes:@{SBTProxyURLProtocolMatchingRuleKey: match}];
     
     @synchronized (self.sharedInstance) {
         [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
@@ -182,8 +182,8 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
 
 + (NSString *)stubRequestsMatching:(SBTRequestMatch *)match stubResponse:(SBTStubResponse *)stubResponse;
 {
-    NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match,
-                                            SBTProxyURLProtocolStubResponse: stubResponse}];
+    NSDictionary *rule = [self makeRuleWithAttributes:@{SBTProxyURLProtocolMatchingRuleKey: match,
+                                                        SBTProxyURLProtocolStubResponse: stubResponse}];
     
     @synchronized (self.sharedInstance) {
         [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
@@ -245,8 +245,8 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
 
 + (NSString *)rewriteRequestsMatching:(SBTRequestMatch *)match rewrite:(SBTRewrite *)rewrite
 {
-    NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match,
-                                            SBTProxyURLProtocolRewriteResponse: rewrite}];
+    NSDictionary *rule = [self makeRuleWithAttributes:@{SBTProxyURLProtocolMatchingRuleKey: match,
+                                                        SBTProxyURLProtocolRewriteResponse: rewrite}];
     @synchronized (self.sharedInstance) {
         [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
@@ -290,9 +290,9 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
 
 + (NSString *)cookieBlockRequestsMatching:(nonnull SBTRequestMatch *)match activeIterations:(NSInteger)activeIterations
 {
-    NSDictionary *rule = [self createRule: @{SBTProxyURLProtocolMatchingRuleKey: match,
-                                             SBTProxyURLProtocolBlockCookiesKey: @(YES),
-                                             SBTProxyURLProtocolBlockCookiesActiveIterationsKey: @(activeIterations)}];
+    NSDictionary *rule = [self makeRuleWithAttributes: @{SBTProxyURLProtocolMatchingRuleKey: match,
+                                                         SBTProxyURLProtocolBlockCookiesKey: @(YES),
+                                                         SBTProxyURLProtocolBlockCookiesActiveIterationsKey: @(activeIterations)}];
     
     @synchronized (self.sharedInstance) {
         [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
@@ -345,7 +345,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     if ([NSURLProtocol propertyForKey:SBTProxyURLProtocolHandledKey inRequest:request]) {
         return NO;
     }
-        
+    
     NSArray *matchingRules = [self matchingRulesForRequest:request];
     return (matchingRules != nil);
 }
@@ -555,7 +555,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     BOOL isRequestRewritten = (rewriteRule != nil);
     
     NSTimeInterval requestTime = -1.0 * [[SBTProxyURLProtocol sharedInstance].tasksTime[task] timeIntervalSinceNow];
-        
+    
     NSData *responseData = [[SBTProxyURLProtocol sharedInstance].tasksData objectForKey:task];
     NSAssert(responseData != nil, @"Should not be nil");
     [[SBTProxyURLProtocol sharedInstance].tasksData removeObjectForKey:task];
@@ -666,7 +666,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
             [self.client URLProtocol:self didLoadData:stubResponse.data];
             [self.client URLProtocolDidFinishLoading:self];
-
+            
             return;
         } else {
             [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
@@ -724,7 +724,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     return ret.count > 0 ? ret : nil;
 }
 
-+ (NSDictionary *)createRule:(NSDictionary *)attributes
++ (NSDictionary *)makeRuleWithAttributes:(NSDictionary *)attributes
 {
     NSString *prefix = nil;
     if (attributes[SBTProxyURLProtocolStubResponse]) {

--- a/Pod/Server/Private/SBTProxyURLProtocol.m
+++ b/Pod/Server/Private/SBTProxyURLProtocol.m
@@ -85,7 +85,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
                                             SBTProxyURLProtocolDelayResponseTimeKey: @(delayResponseTime)}];
     
     @synchronized (self.sharedInstance) {
-        [self.sharedInstance.matchingRules addObject:rule];
+        [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
     
     return rule[SBTProxyURLProtocolMatchingRuleIdentifierKey];
@@ -130,7 +130,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match}];
     
     @synchronized (self.sharedInstance) {
-        [self.sharedInstance.matchingRules addObject:rule];
+        [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
     
     return rule[SBTProxyURLProtocolMatchingRuleIdentifierKey];
@@ -186,7 +186,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
                                             SBTProxyURLProtocolStubResponse: stubResponse}];
     
     @synchronized (self.sharedInstance) {
-        [self.sharedInstance.matchingRules addObject:rule];
+        [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
     
     return rule[SBTProxyURLProtocolMatchingRuleIdentifierKey];
@@ -248,7 +248,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     NSDictionary *rule = [self createRule:@{SBTProxyURLProtocolMatchingRuleKey: match,
                                             SBTProxyURLProtocolRewriteResponse: rewrite}];
     @synchronized (self.sharedInstance) {
-        [self.sharedInstance.matchingRules addObject:rule];
+        [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
     
     return rule[SBTProxyURLProtocolMatchingRuleIdentifierKey];
@@ -295,7 +295,7 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
                                              SBTProxyURLProtocolBlockCookiesActiveIterationsKey: @(activeIterations)}];
     
     @synchronized (self.sharedInstance) {
-        [self.sharedInstance.matchingRules addObject:rule];
+        [self.sharedInstance.matchingRules insertObject:rule atIndex:0];
     }
     
     return rule[SBTProxyURLProtocolMatchingRuleIdentifierKey];

--- a/Pod/Server/Private/SBTProxyURLProtocol.m
+++ b/Pod/Server/Private/SBTProxyURLProtocol.m
@@ -370,21 +370,22 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
     NSDictionary *rewriteRule = nil;
     
     for (NSDictionary *matchingRule in matchingRules) {
+        // Note that we only consider the first instance found for each rule type. We want to "skip" other instances which could be evaluated in future calls.
         if (matchingRule[SBTProxyURLProtocolStubResponse]) {
-            if (stubRule != nil) {
-                NSLog(@"[UITestTunnelServer] Multiple stubs registered for request %@!", self.request);
-                for (NSDictionary *dMatchingRule in matchingRules) {
-                    NSLog(@"[UITestTunnelServer] -> %@", dMatchingRule);
-                }
-            }
-            
+            if (stubRule == nil) {
             stubRule = matchingRule;
+            }
         } else if (matchingRule[SBTProxyURLProtocolRewriteResponse]) {
+            if (rewriteRule == nil) {
             rewriteRule = matchingRule;
+            }
         } else if (matchingRule[SBTProxyURLProtocolBlockCookiesKey]) {
+            if (cookieBlockRule == nil) {
             cookieBlockRule = matchingRule;
+            }
         } else {
             // we can have multiple matching rule here. For example if we throttle and monitor at the same time
+            // TODO: should check for (proxyRule == nil) here? (I cannot fully understand the comment...)
             proxyRule = matchingRule;
         }
     }


### PR DESCRIPTION
Instead of computing a value based on the rule itself. This enables to have multiple "modifiers" (stubs / throttle / monitor etc...) for the same SBTRequestMatch. Since we use an array for storing request match, modifers will be evaluated and applied in a LIFO order.