### PR TITLE
Fix CLLocationManager stop & start stubbing

### DIFF
--- a/Example/SBTUITestTunnel/Main.storyboard
+++ b/Example/SBTUITestTunnel/Main.storyboard
@@ -523,15 +523,24 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nR3-or-wlq">
+                                <rect key="frame" x="133" y="146" width="150" height="30"/>
+                                <state key="normal" title="Stop location updates"/>
+                                <connections>
+                                    <action selector="stopTapped:" destination="ddr-0R-Jhm" eventType="touchUpInside" id="xQT-Wj-2ij"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="u18-q9-vmK" firstAttribute="leading" secondItem="ZCG-Qs-mYC" secondAttribute="leading" constant="16" id="4XR-eU-f7R"/>
+                            <constraint firstItem="nR3-or-wlq" firstAttribute="leading" secondItem="lo7-YO-SrW" secondAttribute="trailing" constant="8" symbolic="YES" id="7bR-YG-KRP"/>
                             <constraint firstItem="dnY-EI-hBw" firstAttribute="top" secondItem="EqA-av-fTp" secondAttribute="bottom" constant="26" id="G6i-sb-TwR"/>
                             <constraint firstItem="lo7-YO-SrW" firstAttribute="top" secondItem="dnY-EI-hBw" secondAttribute="bottom" constant="46" id="JDL-NA-197"/>
                             <constraint firstItem="eCN-GB-ZhH" firstAttribute="leading" secondItem="lo7-YO-SrW" secondAttribute="leading" id="Jn3-jK-kaa"/>
                             <constraint firstItem="u18-q9-vmK" firstAttribute="top" secondItem="dnY-EI-hBw" secondAttribute="bottom" constant="5" id="SQ0-kL-lRv"/>
                             <constraint firstItem="dnY-EI-hBw" firstAttribute="leading" secondItem="ZCG-Qs-mYC" secondAttribute="leading" constant="16" id="g5i-H2-aL7"/>
+                            <constraint firstItem="nR3-or-wlq" firstAttribute="centerY" secondItem="lo7-YO-SrW" secondAttribute="centerY" id="me9-Bn-KFw"/>
                             <constraint firstItem="eCN-GB-ZhH" firstAttribute="top" secondItem="lo7-YO-SrW" secondAttribute="bottom" constant="8" symbolic="YES" id="tr9-Uz-HbC"/>
                             <constraint firstItem="lo7-YO-SrW" firstAttribute="leading" secondItem="dnY-EI-hBw" secondAttribute="leading" id="xxl-Ec-b9V"/>
                         </constraints>

--- a/Example/SBTUITestTunnel/SBTExtensionViewController4.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionViewController4.swift
@@ -28,6 +28,10 @@ class SBTExtensionViewController4: UIViewController, CLLocationManagerDelegate {
     @IBAction func updateTapped(_ sender: Any) {
         locationManager.startUpdatingLocation()
     }
+
+    @IBAction func stopTapped(_ sender: Any) {
+        locationManager.stopUpdatingLocation()
+    }
     
     @IBAction func authorizationStatusTapped(_ sender: Any) {
         statusLabel.text = "\(CLLocationManager.authorizationStatus().rawValue)"

--- a/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
@@ -52,6 +52,31 @@ class CoreLocationTests: XCTestCase {
         
         app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
     }
+
+    func testCoreLocationStopAndResume() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+
+        app.tables.cells["showCoreLocationViewController"].tap()
+        app.buttons["Update location"].tap()
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+
+        wait { self.app.staticTexts["location_pos"].label == "44.0 11.1" }
+
+        app.buttons["Stop location updates"].tap()
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 0.0, longitude: 0.0)])
+        Thread.sleep(forTimeInterval: 2.0)
+        wait { self.app.staticTexts["location_pos"].label == "44.0 11.1" }
+
+        app.buttons["Update location"].tap()
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 11.1, longitude: 44.0)])
+
+        wait(withTimeout: 2) { self.app.staticTexts["location_pos"].label == "11.1 44.0" }
+    }
     
     @available(iOS 14, *)
     func testCoreLocationStubAccuracyAuthorization() {

--- a/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
+++ b/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
@@ -32,6 +32,7 @@
 #import "CLLocationManager+Swizzles.h"
 
 static NSMapTable *_instanceHashTable;
+static NSMapTable *_delegatesHashTable;
 static NSString *_autorizationStatus;
 static NSString *_accuracyAuthorization;
 static NSString *_serviceStatus;
@@ -40,32 +41,32 @@ static NSString *_serviceStatus;
 
 - (void)swz_startMonitoring
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_startUpdatingLocation
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_startUpdatingHeading
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_requestLocation
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_requestAlwaysAuthorization
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_requestWhenInUseAuthorization
 {
-    [_instanceHashTable setObject:[_instanceHashTable objectForKey:self] forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (void)swz_stopMonitoring
@@ -115,7 +116,7 @@ static NSString *_serviceStatus;
 
 - (void)swz_setDelegate:(id<CLLocationManagerDelegate>)delegate
 {
-    [_instanceHashTable setObject:delegate forKey:self];
+    [_delegatesHashTable setObject:delegate forKey:self];
 }
 
 - (id<CLLocationManagerDelegate>)stubbedDelegate
@@ -136,6 +137,7 @@ static NSString *_serviceStatus;
 + (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable
 {
     _instanceHashTable = hashTable;
+    _delegatesHashTable = [hashTable copy];
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -163,6 +165,7 @@ static NSString *_serviceStatus;
 + (void)removeSwizzles
 {
     [_instanceHashTable removeAllObjects];
+    [_delegatesHashTable removeAllObjects];
     
     // Repeat swizzle to restore default implementation
     static dispatch_once_t onceToken;


### PR DESCRIPTION
At the moment when `CLLocationManager` is stopped, the delegate is
removed from `_instanceHashTable` and later when manager is started
again, Swizzles tries to find the delegate from the same table but it is
not there.
To fix that issue, store all delegates on separate `_delegatesHashTable`
and remove only from `_instanceHashTable`. This way it is possible to
access the delegate later when manager resumes.