### PR TITLE
Cache matching rules within a method call

### DIFF
--- a/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
+++ b/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
@@ -406,8 +406,6 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             
             strongSelf.response = [[NSHTTPURLResponse alloc] initWithURL:request.URL statusCode:stubbingStatusCode HTTPVersion:nil headerFields:stubResponse.headers];
             
-            // TODO: this is a re-fetch from before the dispatch. Is that ok?
-            NSArray<NSDictionary *> *matchingRules = [SBTProxyURLProtocol matchingRulesForRequest:self.request];
             if ([strongSelf monitorRuleFromMatchingRules:matchingRules] != nil) {
                 SBTMonitoredNetworkRequest *monitoredRequest = [[SBTMonitoredNetworkRequest alloc] init];
                 
@@ -489,7 +487,6 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             [self moveCookiesToHeader:newRequest];
         }
         
-        // TODO: do we need to do this at all? why not use rewriteRule?
         SBTRewrite *rewrite = [self rewriteRuleFromMatchingRules:matchingRules][SBTProxyURLProtocolRewriteResponse];
         if (rewrite != nil) {
             newRequest.URL = [rewrite rewriteUrl:newRequest.URL];


### PR DESCRIPTION
# Problem

If there are a lot of rules, or if one or more of them is slow to execute its matching function, then SBTProxyURLProtocol can take a long time to respond to the calling app. The impact is the tests are slow to run, or sometimes the app even receives a network timeout error.

Currently `[SBTProxyURLProtocol startLoading]` executes rule matching against the current request a minimum of five times, in order to determine the matching stubs, rewrites, cookies, monitors, and throttling requests.

# Solution

Update `[SBTProxyURLProtocol startLoading]` to find the matching rules once, then pass those matching rules into methods to extract the matching stubs, rewrites, cookies, monitors, and throttling request.

The impact is speeding up UI test speed.