### PR TITLE
Add missing swizzling macros in UNUserNotificationCenter and CLLocationManager headers

### DIFF
--- a/Documentation/Setup.md
+++ b/Documentation/Setup.md
@@ -61,3 +61,5 @@ post_install do |installer|
     end
 end
 ```
+
+**Note**: You can set `ENABLE_UITUNNEL_SWIZZLING=0` if you plan on disabling swizzling and having your own sub-class of `XCUIApplication` instead of the automatically provided one.

--- a/SBTUITestTunnelClient.podspec
+++ b/SBTUITestTunnelClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelClient"
-    s.version          = "8.3.0"
+    s.version          = "8.3.1"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/SBTUITestTunnelCommon.podspec
+++ b/SBTUITestTunnelCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelCommon"
-    s.version          = "8.3.0"
+    s.version          = "8.3.1"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/SBTUITestTunnelServer.podspec
+++ b/SBTUITestTunnelServer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelServer"
-    s.version          = "8.3.0"
+    s.version          = "8.3.1"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.h
+++ b/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.h
@@ -24,19 +24,21 @@
     #endif
 #endif
 
-#if ENABLE_UITUNNEL && ENABLE_UITUNNEL_SWIZZLING
+#if ENABLE_UITUNNEL
+  #ifdef ENABLE_UITUNNEL_SWIZZLING
 
-@import CoreLocation;
+    @import CoreLocation;
 
-@interface CLLocationManager (Swizzles)
+    @interface CLLocationManager (Swizzles)
 
-+ (void)setStubbedAuthorizationStatus:(NSString *)autorizationStatus;
-+ (void)setStubbedAccuracyAuthorization:(NSString *)accuracyAuthorization API_AVAILABLE(ios(14));
-+ (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable;
-+ (void)removeSwizzles;
+    + (void)setStubbedAuthorizationStatus:(NSString *)autorizationStatus;
+    + (void)setStubbedAccuracyAuthorization:(NSString *)accuracyAuthorization API_AVAILABLE(ios(14));
+    + (void)loadSwizzlesWithInstanceHashTable:(NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>>*)hashTable;
+    + (void)removeSwizzles;
 
-- (id<CLLocationManagerDelegate>)stubbedDelegate;
+    - (id<CLLocationManagerDelegate>)stubbedDelegate;
 
-@end
+    @end
 
+  #endif
 #endif

--- a/Sources/SBTUITestTunnelServer/private/UNUserNotificationCenter+Swizzles.h
+++ b/Sources/SBTUITestTunnelServer/private/UNUserNotificationCenter+Swizzles.h
@@ -24,15 +24,17 @@
     #endif
 #endif
 
-#if ENABLE_UITUNNEL && ENABLE_UITUNNEL_SWIZZLING
+#if ENABLE_UITUNNEL
+  #ifdef ENABLE_UITUNNEL_SWIZZLING
 
-@import UserNotifications;
+    @import UserNotifications;
 
-@interface UNUserNotificationCenter (Swizzles)
+    @interface UNUserNotificationCenter (Swizzles)
 
-+ (void)loadSwizzlesWithAuthorizationStatus:(NSString *)autorizationStatus;
-+ (void)removeSwizzles;
+    + (void)loadSwizzlesWithAuthorizationStatus:(NSString *)autorizationStatus;
+    + (void)removeSwizzles;
 
-@end
+    @end
 
+  #endif
 #endif


### PR DESCRIPTION
When using a custom build config name, like QA, the pod fails to build when `ENABLE_UITUNNEL_SWIZZLING=0` under `GCC_PREPROCESSOR_DEFINITIONS` in the `Podfile`.

![Screen Shot 2022-04-26 at 4 53 37 PM](https://user-images.githubusercontent.com/4314581/165411110-d8a2eee5-cb1e-4506-83d6-cc39e2b948ef.jpg)

This change makes it work regardless of the value as long as it's defined.