### PR TITLE
Fixing calling the wrong method which is causing an infinite recursion

### DIFF
--- a/Sources/SBTUITestTunnelServer/private/NSURLSession+HTTPBodyFix.m
+++ b/Sources/SBTUITestTunnelServer/private/NSURLSession+HTTPBodyFix.m
@@ -60,7 +60,7 @@
 
 - (NSURLSessionUploadTask *)swz_uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 {    
-    return [self uploadTaskWithRequest:request fromFile:fileURL completionHandler:completionHandler];
+    return [self swz_uploadTaskWithRequest:request fromFile:fileURL completionHandler:completionHandler];
 }
 
 - (NSURLSessionDataTask *)swz_dataTaskWithRequest:(NSURLRequest *)request


### PR DESCRIPTION
Currently calling `uploadTaskWithRequest:fromFile` is causing a crash due to infinite recursion due to calling the wrong method