### PR TITLE
Rename scroll API

### DIFF
--- a/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
@@ -165,7 +165,7 @@ class MiscellaneousTests: XCTestCase {
         
         XCTAssertFalse(app.staticTexts["Label5"].isHittable)
         
-        XCTAssertTrue(app.scrollTableView(withIdentifier: "table", toRow: 100, animated: false))
+        XCTAssertTrue(app.scrollTableView(withIdentifier: "table", toRowIndex: 100, animated: false))
         
         XCTAssert(app.staticTexts["Label5"].isHittable)
     }
@@ -189,7 +189,7 @@ class MiscellaneousTests: XCTestCase {
 
         XCTAssertFalse(app.staticTexts["30"].isHittable)
 
-        XCTAssertTrue(app.scrollCollectionView(withIdentifier: "collection", toRow: 30, animated: true))
+        XCTAssertTrue(app.scrollCollectionView(withIdentifier: "collection", toElementIndex: 30, animated: true))
         XCTAssert(app.staticTexts["30"].isHittable)
 
         XCTAssertFalse(app.staticTexts["50"].isHittable)
@@ -205,7 +205,7 @@ class MiscellaneousTests: XCTestCase {
 
         XCTAssertFalse(app.staticTexts["10"].isHittable)
 
-        XCTAssertTrue(app.scrollCollectionView(withIdentifier: "collection", toRow: 10, animated: true))
+        XCTAssertTrue(app.scrollCollectionView(withIdentifier: "collection", toElementIndex: 10, animated: true))
         XCTAssert(app.staticTexts["10"].isHittable)
 
         XCTAssertFalse(app.staticTexts["40"].isHittable)

--- a/SBTUITestTunnelClient.podspec
+++ b/SBTUITestTunnelClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelClient"
-    s.version          = "8.3.0"
+    s.version          = "9.0.0"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/SBTUITestTunnelCommon.podspec
+++ b/SBTUITestTunnelCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelCommon"
-    s.version          = "8.3.0"
+    s.version          = "9.0.0"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/SBTUITestTunnelServer.podspec
+++ b/SBTUITestTunnelServer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SBTUITestTunnelServer"
-    s.version          = "8.3.0"
+    s.version          = "9.0.0"
     s.summary          = "Enable network mocks and more in UI Tests"
 
     s.description      = <<-DESC

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -688,7 +688,7 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
 
 #pragma mark - XCUITest scroll extensions
 
-- (BOOL)scrollTableViewWithIdentifier:(NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag
+- (BOOL)scrollTableViewWithIdentifier:(NSString *)identifier toRowIndex:(NSInteger)row animated:(BOOL)flag
 {
     NSAssert([identifier length] > 0, @"Invalid empty identifier!");
     
@@ -711,7 +711,7 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     return [[self sendSynchronousRequestWithPath:SBTUITunneledApplicationCommandXCUIExtensionScrollTableView params:params] boolValue];
 }
 
-- (BOOL)scrollCollectionViewWithIdentifier:(NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag
+- (BOOL)scrollCollectionViewWithIdentifier:(NSString *)identifier toElementIndex:(NSInteger)row animated:(BOOL)flag
 {
     NSAssert([identifier length] > 0, @"Invalid empty identifier!");
     

--- a/Sources/SBTUITestTunnelClient/SBTUITunneledApplication.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITunneledApplication.m
@@ -342,9 +342,9 @@
 
 #pragma mark - XCUITest scroll extensions
 
-- (BOOL)scrollTableViewWithIdentifier:(nonnull NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag
+- (BOOL)scrollTableViewWithIdentifier:(nonnull NSString *)identifier toRowIndex:(NSInteger)index animated:(BOOL)flag
 {
-    return [self.client scrollTableViewWithIdentifier:identifier toRow:row animated:flag];
+    return [self.client scrollTableViewWithIdentifier:identifier toRowIndex:index animated:flag];
 }
 
 - (BOOL)scrollTableViewWithIdentifier:(nonnull NSString *)identifier toElementWithIdentifier:(nonnull NSString *)targetIdentifier animated:(BOOL)flag {
@@ -352,9 +352,9 @@
 }
 
 
-- (BOOL)scrollCollectionViewWithIdentifier:(nonnull NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag
+- (BOOL)scrollCollectionViewWithIdentifier:(nonnull NSString *)identifier toElementIndex:(NSInteger)index animated:(BOOL)flag
 {
-    return [self.client scrollCollectionViewWithIdentifier:identifier toRow:row animated:flag];
+    return [self.client scrollCollectionViewWithIdentifier:identifier toElementIndex:index animated:flag];
 }
 
 - (BOOL)scrollCollectionViewWithIdentifier:(nonnull NSString *)identifier toElementWithIdentifier:(nonnull NSString *)targetIdentifier animated:(BOOL)flag {

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
@@ -479,12 +479,12 @@
  *  Scroll UITablewViews view to the specified row (flattening sections if any).
  *
  *  @param identifier accessibilityIdentifier of the UITableView
- *  @param row the row to scroll the element to. This value flattens sections (if more than one is returned by the dataSource) and is best effort meaning it will stop at the last cell if the passed number if larger than the available cells. Passing NSIntegerMax guarantees to scroll to last cell.
+ *  @param index the index of the row to scroll the element to. This value flattens sections (if more than one is returned by the dataSource) and is best effort meaning it will stop at the last cell if the passed number if larger than the available cells. Passing NSIntegerMax guarantees to scroll to last cell.
  *  @param flag pass YES to animate the scroll; otherwise, pass NO
  *
  *  @return `YES` on success
  */
-- (BOOL)scrollTableViewWithIdentifier:(nonnull NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag;
+- (BOOL)scrollTableViewWithIdentifier:(nonnull NSString *)identifier toRowIndex:(NSInteger)index animated:(BOOL)flag;
 
 /**
  *  Scroll UITablewViews view to the specified row (flattening sections if any).
@@ -501,12 +501,12 @@
  *  Scroll UICollection view to the specified row (flattening sections if any).
  *
  *  @param identifier accessibilityIdentifier of the UICollectionView
- *  @param row the row to scroll the element to. This value flattens sections (if more than one is returned by the dataSource) and is best effort meaning it will stop at the last cell if the passed number if larger than the available cells. Passing NSIntegerMax guarantees to scroll to last cell.
+ *  @param index the index of the element to scroll the element to. This value flattens sections (if more than one is returned by the dataSource) and is best effort meaning it will stop at the last cell if the passed number if larger than the available cells. Passing NSIntegerMax guarantees to scroll to last cell.
  *  @param flag pass YES to animate the scroll; otherwise, pass NO
  *
  *  @return `YES` on success
 */
-- (BOOL)scrollCollectionViewWithIdentifier:(nonnull NSString *)identifier toRow:(NSInteger)row animated:(BOOL)flag;
+- (BOOL)scrollCollectionViewWithIdentifier:(nonnull NSString *)identifier toElementIndex:(NSInteger)index animated:(BOOL)flag;
 
 /**
  *  Scroll UICollection view to the specified row (flattening sections if any).


### PR DESCRIPTION
As requested in #150, this small PR rename the scroll extension API to better reflect the differences of scrolling a tableview and a collectionview, and make it more clear that the parameter to be passed is the row/element index