### PR TITLE
Fix cocoapods badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SBTUITestTunnel
 
-[![Version](https://img.shields.io/cocoapods/v/SBTUITestTunnelServer.svg?style=flat)](http://cocoadocs.org/docsets/SBTUITestTunnel)
-[![License](https://img.shields.io/cocoapods/l/SBTUITestTunnel.svg?style=flat)](http://cocoadocs.org/docsets/SBTUITestTunnel)
-[![Platform](https://img.shields.io/cocoapods/p/SBTUITestTunnel.svg?style=flat)](http://cocoadocs.org/docsets/SBTUITestTunnel)
+[![Version](https://img.shields.io/cocoapods/v/SBTUITestTunnelServer)](https://cocoapods.org/pods/SBTUITestTunnel)
+[![License](https://img.shields.io/cocoapods/l/SBTUITestTunnel)](https://cocoapods.org/pods/SBTUITestTunnel)
+[![Platform](https://img.shields.io/cocoapods/p/SBTUITestTunnel)](https://cocoapods.org/pods/SBTUITestTunnel)
 [![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-green?style=flat)](https://img.shields.io/badge/Swift_Package_Manager-compatible-green?style=flat)
 
 ## Overview


### PR DESCRIPTION
* The URL pointing to cocoadocs.org was broken
* Simplify img.shields.io URL