### PR TITLE
Improve CLLocationManagerDelegate authorizationStatus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ Example/Pods/
 Example/Podfile.lock
 Example/SBTUITestTunnel.xcodeproj/
 Example/SBTUITestTunnel.xcworkspace/
+
+# SwiftPM resolved files
+*.resolved

--- a/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
@@ -31,16 +31,22 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = .white
+
         statusLabel.text = "-"
+        statusLabel.textColor = .black
         statusLabel.accessibilityIdentifier = "location_status"
 
         locationLabel.text = "-"
+        locationLabel.textColor = .black
         locationLabel.accessibilityIdentifier = "location_pos"
 
         threadLabel.text = "-"
+        threadLabel.textColor = .black
         threadLabel.accessibilityIdentifier = "location_thread"
         
         currentLocationLabel.text = "-"
+        currentLocationLabel.textColor = .black
         currentLocationLabel.accessibilityIdentifier = "manager_location"
 
         authorizationButton.setTitle("Authorization status", for: .normal)

--- a/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
@@ -94,7 +94,11 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
     }
 
     @objc func authorizationStatusTapped(_ sender: Any) {
-        statusLabel.text = "\(CLLocationManager.authorizationStatus().description)"
+        if #available(iOS 14.0, *) {
+            statusLabel.text = "\(locationManager.authorizationStatus.description)"
+        } else {
+            statusLabel.text = "\(CLLocationManager.authorizationStatus().description)"
+        }
     }
     
     @objc func currentLocationTapped(_ sender: Any) {

--- a/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
@@ -17,22 +17,30 @@ class CoreLocationTests: XCTestCase {
         app.coreLocationStubEnabled(true)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
 
+        app.tables.cells["showCoreLocationViewController"].tap()
+        wait { self.app.staticTexts["location_status"].label == "-" }
+
         app.coreLocationStubAuthorizationStatus(.notDetermined)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .notDetermined)
+        wait { self.app.staticTexts["location_status"].label == "notDetermined" }
 
         app.coreLocationStubAuthorizationStatus(.denied)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .denied)
+        wait { self.app.staticTexts["location_status"].label == "denied" }
         
         app.coreLocationStubAuthorizationStatus(.restricted)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .restricted)
+        wait { self.app.staticTexts["location_status"].label == "restricted" }
 
         app.coreLocationStubAuthorizationStatus(.authorizedWhenInUse)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedWhenInUse)
+        wait { self.app.staticTexts["location_status"].label == "authorizedWhenInUse" }
 
         app.coreLocationStubAuthorizationStatus(.authorizedAlways)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+        wait { self.app.staticTexts["location_status"].label == "authorizedAlways" }
     }
-    
+
     func testCoreLocationUpdate() {
         app.launchTunnel()
 

--- a/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
+++ b/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
@@ -118,6 +118,7 @@ static NSString *_serviceStatus;
 - (void)swz_setDelegate:(id<CLLocationManagerDelegate>)delegate
 {
     [_delegatesHashTable setObject:delegate forKey:self];
+    [_instanceHashTable setObject:[_delegatesHashTable objectForKey:self] forKey:self];
 }
 
 - (id<CLLocationManagerDelegate>)stubbedDelegate


### PR DESCRIPTION
This PR should improve the support for `CLLocationManagerDelegate` delegate functions:

- `locationManagerDidChangeAuthorization(_:)` [[Doc](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/3563956-locationmanagerdidchangeauthoriz)]
- `locationManager(_:didChangeAuthorization:)` [[Doc](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423701-locationmanager)] _Deprecated starting from iOS 14_

Based on Apple documentation this should be the behaviour of these methods:

> The system calls this method when the app creates the related object’s [CLLocationManager](https://developer.apple.com/documentation/corelocation/cllocationmanager) instance, and when the app’s authorization status changes. The status informs the app whether it can access the user’s location.

The proposed implementation update the sample app to implement these methods and add a small fix to the tunnel server in order to populate the `_instanceHashTable` with the correct value as soon as a `setDelegate` is called, allowing a correct dispatch of the `coreLocationStubAuthorizationStatus`.