### PR TITLE
Improve CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,33 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
-    name: Build App and run UI Test
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ios: "15.5"
+            os: "macos-12"
+            xcode: "13.4"
+          - ios: "16.2"
+            os: "macos-12"
+            xcode: "14.2"
+    name: Run UI Test on iOS ${{ matrix.ios }}
+    runs-on: ${{ matrix.os }}
     env:
       platform: ${{ 'iOS Simulator' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Required Tools
+      - name: Install required tools
         run: |
           brew update
           brew install xcodegen
+      - name: Select Xcode version ${{ matrix.xcode }}
+        run: |
+          sudo xcversion select ${{ matrix.xcode }}
       - name: Generate project
         run: |
           cd Example
@@ -22,9 +35,21 @@ jobs:
       - name: Build App
         run: |
           Scripts/run_build.rb
-      - name: Run internal UI Tests
+      - name: Run UI Tests
         run: |
           Scripts/run_uitests.rb
+      - name: Collect UI Tests artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: SBTUITestTunnel_Tests_iOS_${{ matrix.ios }}.xcresult
+          path: SBTUITestTunnel_Tests.xcresult
+        if: success() || failure()
       - name: Run no swizzling UI Tests
         run: |
           Scripts/run_uitests_no_swizzling.rb
+      - name: Collect no swizzling UI Tests artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: SBTUITestTunnel_TestsNoSwizzling_iOS_${{ matrix.ios }}.xcresult
+          path: SBTUITestTunnel_TestsNoSwizzling.xcresult
+        if: success() || failure()

--- a/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
@@ -109,9 +109,9 @@ class MiscellaneousTests: XCTestCase {
         app.stubRequests(matching: requestMatch, response: response)
         
         app.cells["executeDataTaskRequest"].tap()
-        
-        wait { (self.app.textViews["result"].value as? String)?.isEmpty == false }
-        
+
+        let textResult = app.textViews["result"]
+        wait { textResult.exists }
         let result = app.textViews["result"].value as! String
         let resultData = Data(base64Encoded: result)!
         let resultDict = try! JSONSerialization.jsonObject(with: resultData, options: []) as! [String: Any]

--- a/Scripts/run_build.rb
+++ b/Scripts/run_build.rb
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
 require_relative 'build_lib'
-Build.run_build()
+exit Build.run_build()

--- a/Scripts/run_uitests.rb
+++ b/Scripts/run_uitests.rb
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
 require_relative 'build_lib'
-Build.run_ui_tests()
+exit Build.run_ui_tests()

--- a/Scripts/run_uitests_no_swizzling.rb
+++ b/Scripts/run_uitests_no_swizzling.rb
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
 require_relative 'build_lib'
-Build.run_ui_tests_no_swizzling()
+exit Build.run_ui_tests_no_swizzling()


### PR DESCRIPTION
The following PR allows running the tests on different iOS versions. The main goal was to keep the running time the same, so the proposed implementation is just using the Xcode versions available from the current Github Actions [runner images](https://github.com/actions/runner-images).

In detail we will use the latest [macos-12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md) image for testing:
- `iOS 15.5 (Xcode 13.4)` 
- `iOS 16.2 (Xcode 14.2)`

I also fixed how the ruby scripts returned the result (the CI didn't correctly detect some failures). On this note, the **CI might fail** due to flaky tests or `xcodebuild` crashes during test execution. Now that the failure reporting is fixed it should be easier to address the first issue and improve test reliability in future PRs.