### PR TITLE
Fix build errors when `Warnings as Errors` is enabled

### DIFF
--- a/Sources/SBTUITestTunnelCommon/include/SBTUITestTunnelCommon.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTUITestTunnelCommon.h
@@ -20,8 +20,6 @@
     #endif
 #endif
 
-#if ENABLE_UITUNNEL
-
 #import "SBTMonitoredNetworkRequest.h"
 #import "SBTRequestMatch.h"
 #import "SBTRewrite.h"
@@ -31,6 +29,8 @@
 #import "SBTSwizzleHelpers.h"
 #import "SBTUITestTunnel.h"
 #import "SBTIPCTunnel.h"
+
+#if ENABLE_UITUNNEL
 
 #ifdef SPM
     #import "../DetoxIPC/DTXIPCConnection.h"

--- a/Sources/SBTUITestTunnelServer/include/SBTUITestTunnelServer.h
+++ b/Sources/SBTUITestTunnelServer/include/SBTUITestTunnelServer.h
@@ -20,14 +20,14 @@
     #endif
 #endif
 
-#if ENABLE_UITUNNEL
-
 @import Foundation;
 
 // These imports are required for SPM as this file will be the umbrella header
 #import "UIViewController+SBTUITestTunnel.h"
 #import "UIScrollView+SBTUITestTunnel.h"
 #import "SBTAnyViewControllerPreviewing.h"
+
+#if ENABLE_UITUNNEL
 
 @interface SBTUITestTunnelServer : NSObject
 


### PR DESCRIPTION
When using SPM to link SBTUITestTunnelServer to a target with `Warnings as errors` enabled for, Release builds fail due to headers that are specified in SPM not being included in the umbrella header.

SPM generates warnings if the umbrella header of a package does not include the headers specified in the package definition.

If a build target has `Warnings as Errors` enabled, this leads to build failures when building in RELEASE (e.g. to archive) because the current the `#import` statements in the umbrella header are removed because `ENABLE_UITUNNEL` and `DEBUG` are false.   Since the contents of each of these headers is also protected by `#if ENABLE_UITUNNEL`, the `#import` statements should always be included to meet the requirements of SPM but will be empty when built for archiving.

This PR moves the headers to always be imported regardless of `ENABLE_UITUNNEL` and relies on the contents of those files to appropriately be empty when not being built for DEBUG.

Here is a repo we put together that shows the issue on a sample project, along with a branch using the dependency with this fix: https://github.com/waltflanagan/SBTUITestTunnelBug