### PR TITLE
Enable SBTUITestTunnelServer to be used from CocoaPods without `use_frameworks!`

### DIFF
--- a/SBTUITestTunnelServer.podspec
+++ b/SBTUITestTunnelServer.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/SBTUITestTunnelServer/**/*.{h,m}"
 
-  s.dependency "SBTUITestTunnelCommon", "#{s.version}"
+  s.dependency "SBTUITestTunnelCommon", "#{s.version}", :git => 'https://github.com/djs-code/SBTUITestTunnel.git'
   s.dependency "GCDWebServer-SBTUITestTunnel"
 end

--- a/SBTUITestTunnelServer.podspec
+++ b/SBTUITestTunnelServer.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/SBTUITestTunnelServer/**/*.{h,m}"
 
-  s.dependency "SBTUITestTunnelCommon", "#{s.version}", :git => 'https://github.com/djs-code/SBTUITestTunnel.git'
+  s.dependency "SBTUITestTunnelCommon", "#{s.version}"
   s.dependency "GCDWebServer-SBTUITestTunnel"
 end

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -28,9 +28,13 @@
 
 #if defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
 @import GCDWebServer;
+oirutoiret
 #elif defined(__has_include) && __has_include("GCDWebServer.h") && __has_include("GCDWebServerPrivate.h")
 #import "GCDWebServer.h"
 #import "GCDWebServerPrivate.h"
+lsdfjlkds
+#else
+bgbggbgn
 #endif
 
 @import SBTUITestTunnelCommon;

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -27,16 +27,12 @@
 #endif
 
 #ifdef SPM
-@import GCDWebServer;
+    @import GCDWebServer;
 #elif defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
-@import GCDWebServer;
-oirutoiret
+    @import GCDWebServer;
 #elif defined(__has_include) && __has_include("GCDWebServer.h") && __has_include("GCDWebServerPrivate.h")
-#import "GCDWebServer.h"
-#import "GCDWebServerPrivate.h"
-lsdfjlkds
-#else
-bgbggbgn
+    #import "GCDWebServer.h"
+    #import "GCDWebServerPrivate.h"
 #endif
 
 @import SBTUITestTunnelCommon;

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -26,8 +26,13 @@
     @import SBTUITestTunnelCommonNoARC;
 #endif
 
-@import SBTUITestTunnelCommon;
+#if defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
 @import GCDWebServer;
+#elif defined(__has_include) && __has_include("GCDWebServer.h")
+#import "GCDWebServer.h"
+#endif
+
+@import SBTUITestTunnelCommon;
 @import CoreLocation;
 @import UserNotifications;
 

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -28,8 +28,9 @@
 
 #if defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
 @import GCDWebServer;
-#elif defined(__has_include) && __has_include("GCDWebServer.h")
+#elif defined(__has_include) && __has_include("GCDWebServer.h") && __has_include("GCDWebServerPrivate.h")
 #import "GCDWebServer.h"
+#import "GCDWebServerPrivate.h"
 #endif
 
 @import SBTUITestTunnelCommon;

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -26,7 +26,9 @@
     @import SBTUITestTunnelCommonNoARC;
 #endif
 
-#if defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
+#ifdef SPM
+@import GCDWebServer;
+#elif defined(__has_include) && __has_include(<GCDWebServer/GCDWebServer.h>)
 @import GCDWebServer;
 oirutoiret
 #elif defined(__has_include) && __has_include("GCDWebServer.h") && __has_include("GCDWebServerPrivate.h")


### PR DESCRIPTION
This PR adds some pre-processor logic to enable SBTUITestTunnelServer to be used from CocoaPods without the need for `use_frameworks!`.