### PR TITLE
CoreLocation delegate on main thread

### DIFF
--- a/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
@@ -24,8 +24,9 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
     private let stopLocationUpdateButton = UIButton()
     private let currentLocationButton = UIButton()
     private let statusLabel = UILabel()
+    private let statusThreadLabel = UILabel()
     private let locationLabel = UILabel()
-    private let threadLabel = UILabel()
+    private let locationThreadLabel = UILabel()
     private let currentLocationLabel = UILabel()
     private let locationManager = CLLocationManager()
 
@@ -38,13 +39,17 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
         statusLabel.textColor = .black
         statusLabel.accessibilityIdentifier = "location_status"
 
+        statusThreadLabel.text = "-"
+        statusThreadLabel.textColor = .black
+        statusThreadLabel.accessibilityIdentifier = "location_status_thread"
+
         locationLabel.text = "-"
         locationLabel.textColor = .black
         locationLabel.accessibilityIdentifier = "location_pos"
 
-        threadLabel.text = "-"
-        threadLabel.textColor = .black
-        threadLabel.accessibilityIdentifier = "location_thread"
+        locationThreadLabel.text = "-"
+        locationThreadLabel.textColor = .black
+        locationThreadLabel.accessibilityIdentifier = "location_thread"
         
         currentLocationLabel.text = "-"
         currentLocationLabel.textColor = .black
@@ -65,8 +70,8 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
         stopLocationUpdateButton.addTarget(self, action: #selector(stopTapped), for: .touchUpInside)
         currentLocationButton.addTarget(self, action: #selector(currentLocationTapped), for: .touchUpInside)
 
-        let statusStack = UIStackView(arrangedSubviews: [authorizationButton, statusLabel])
-        let locationStack = UIStackView(arrangedSubviews: [updateLocationButton, stopLocationUpdateButton, currentLocationButton, locationLabel, threadLabel, currentLocationLabel])
+        let statusStack = UIStackView(arrangedSubviews: [authorizationButton, statusLabel, statusThreadLabel])
+        let locationStack = UIStackView(arrangedSubviews: [updateLocationButton, stopLocationUpdateButton, currentLocationButton, locationLabel, locationThreadLabel, currentLocationLabel])
         let contentStack = UIStackView(arrangedSubviews: [statusStack, locationStack])
 
         [statusStack, locationStack, contentStack].forEach {
@@ -113,17 +118,21 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
 @available(iOS 14.0, *)
 extension SBTExtensionCoreLocationViewController {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let threadName = Thread.isMainThread ? "Main" : "Not main"
         DispatchQueue.main.async { [weak self] in
             self?.statusLabel.text = manager.authorizationStatus.description
+            self?.statusThreadLabel.text = threadName
         }
     }
 }
 
 extension SBTExtensionCoreLocationViewController {
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        let threadName = Thread.isMainThread ? "Main" : "Not main"
         if #unavailable(iOS 14.0) {
             DispatchQueue.main.async { [weak self] in
                 self?.statusLabel.text = status.description
+                self?.statusThreadLabel.text = threadName
             }
         }
     }
@@ -134,7 +143,7 @@ extension SBTExtensionCoreLocationViewController {
         let threadName = Thread.isMainThread ? "Main" : "Not main"
         DispatchQueue.main.async { [weak self] in
             self?.locationLabel.text = locations.map { "\($0.coordinate.latitude) \($0.coordinate.longitude)" }.joined(separator: "+")
-            self?.threadLabel.text = threadName
+            self?.locationThreadLabel.text = threadName
         }
     }
 }

--- a/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
@@ -105,7 +105,7 @@ class CoreLocationTests: XCTestCase {
                 app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
                 Thread.sleep(forTimeInterval: 1.0)
                 XCTAssertEqual(app.staticTexts["location_pos"].label, "-", "Unexpected update with status \(status)")
-                XCTAssertEqual(app.staticTexts["location_pos"].label, "-", "Unexpected update with status \(status)")
+                XCTAssertEqual(app.staticTexts["location_status_thread"].label, "Main", "Unexpected status update on Not main thread")
             }
         }
         
@@ -116,9 +116,11 @@ class CoreLocationTests: XCTestCase {
                 app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1 + statusIndex)])
 
                 wait(withTimeout: 2) {
-                    self.app.staticTexts["location_pos"].label == "44.0 \(11.1 + statusIndex)" &&
-                    self.app.staticTexts["location_thread"].label == "Main"
+                    self.app.staticTexts["location_pos"].label == "44.0 \(11.1 + statusIndex)"
                 }
+
+                XCTAssertEqual(app.staticTexts["location_thread"].label, "Main", "Unexpected location update on Not main thread")
+                XCTAssertEqual(app.staticTexts["location_status_thread"].label, "Main", "Unexpected status update on Not main thread")
 
                 statusIndex += 1.0
             }

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
@@ -550,6 +550,10 @@
 /**
  *  Enable CLLocationManager stubbing
  *
+ *  All calls to `CLLocationManagerDelegate` methods will be invoked on the `Main` thread, simplifying the requirements for [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager) :
+ *
+ *  _Core Location calls the methods of your delegate object using the NSRunLoop of the thread on which you initialized the CLLocationManager object. That thread must itself have an active NSRunLoop, like the one found in your app’s main thread._
+ *
  *  @param flag stubbing status
  *
  *  @return `YES` on success
@@ -559,20 +563,24 @@
 /**
  *  Stub CLLocationManager authorizationStatus
  *
- *  @param status location authorization status. The default value returned by `+[CLLocationManager authorizationStatus]` when enabling core location stubbing is kCLAuthorizationStatusAuthorizedAlways
+ *  @param status location authorization status. The default value returned by `+[CLLocationManager authorizationStatus]` when enabling core location stubbing is `kCLAuthorizationStatusAuthorizedAlways`
+ *
+ *  The `CLLocationManagerDelegate` methods: `locationManager:didChangeAuthorizationStatus:` and `locationManagerDidChangeAuthorization:` will be called on the `Main` thread.
  *
  *  @return `YES` on success
 */
 - (BOOL)coreLocationStubAuthorizationStatus:(CLAuthorizationStatus)status;
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 /**
  *  Stub CLLocationManager accuracyAuthorization
  *
- *  @param authorization accuracy authorization. The default value returned by `CLLocationManager.accuracyAuthorization` when enabling core location stubbing is CLAccuracyAuthorizationFullAccuracy
+ *  @param authorization accuracy authorization. The default value returned by `CLLocationManager.accuracyAuthorization` when enabling core location stubbing is `CLAccuracyAuthorizationFullAccuracy`
+ *
+ *  The `CLLocationManagerDelegate` method `locationManagerDidChangeAuthorization:` will be called on the `Main` thread.
  *
  *  @return `YES` on success
 */
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 - (BOOL)coreLocationStubAccuracyAuthorization:(CLAccuracyAuthorization)authorization API_AVAILABLE(ios(14));
 #endif
 
@@ -587,18 +595,18 @@
 - (BOOL)coreLocationStubLocationServicesEnabled:(BOOL)flag;
 
 /**
- *  Tells all active CLLocationManager's delegates that the location manager
- *  has a new location data available.
+ *  Tells all active CLLocationManager's delegates that the location manager has a new location data available.
  *
  *  @param locations an array of CLLocation objects containing the location data. This array should always contains at least one object representing the current location
+ *
+ *  The `CLLocationManagerDelegate` method `locationManager:didUpdateLocations:` will be called on the `Main` thread.
  *
  *  @return `YES` on success
 */
 - (BOOL)coreLocationNotifyLocationUpdate:(nonnull NSArray<CLLocation *>*)locations;
 
 /**
- *  Updates the current location of all active CLLocationManager's at the
- *  provided location.
+ *  Updates the current location of all active CLLocationManager's at the provided location.
  *
  *  @param location a CLLocation object containing the location data
  *
@@ -607,10 +615,11 @@
 - (BOOL)coreLocationStubManagerLocation:(nullable CLLocation *)location;
 
 /**
- *  Tells all active CLLocationManager's delegates that the location manager
- *  was unable to retrieve a location value.
+ *  Tells all active CLLocationManager's delegates that the location manager was unable to retrieve a location value.
  *
  *  @param error the error object containing the reason the location or heading could not be retrieved.
+ *
+ *  The `CLLocationManagerDelegate` method `locationManager:didFailWithError:` will be called on the `Main` thread.
  *
  *  @return `YES` on success
 */

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -1232,12 +1232,16 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
         [CLLocationManager setStubbedAuthorizationStatus:authorizationStatus];
         for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
             if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManager:didChangeAuthorizationStatus:)]) {
-                [locationManager.stubbedDelegate locationManager:locationManager didChangeAuthorizationStatus:authorizationStatus.intValue];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [locationManager.stubbedDelegate locationManager:locationManager didChangeAuthorizationStatus:authorizationStatus.intValue];
+                });
             }
             #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
                 if (@available(iOS 14.0, *)) {
                     if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManagerDidChangeAuthorization:)]) {
-                        [locationManager.stubbedDelegate locationManagerDidChangeAuthorization:locationManager];
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            [locationManager.stubbedDelegate locationManagerDidChangeAuthorization:locationManager];
+                        });
                     }
                 }
             #endif
@@ -1317,7 +1321,9 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
         
         for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
             if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManager:didFailWithError:)]) {
-                [locationManager.stubbedDelegate locationManager:locationManager didFailWithError:error];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [locationManager.stubbedDelegate locationManager:locationManager didFailWithError:error];
+                });
             }
         }
     #endif


### PR DESCRIPTION
This is a follow up of #160 , adding the remaining `CoreLocationManager` delegate functions to be dispatched on the `main` thread.