### PR TITLE
Add support for launching the app with a URL

### DIFF
--- a/Example/SBTUITestTunnel/SBTAppDelegate.m
+++ b/Example/SBTUITestTunnel/SBTAppDelegate.m
@@ -25,16 +25,20 @@
 {
     [SBTUITestTunnelServer registerCustomCommandNamed:@"myCustomCommandReturnNil" block:^NSObject *(NSObject *object) {
         [[NSUserDefaults standardUserDefaults] setObject:object forKey:@"custom_command_test"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
 
         return nil;
     }];
     [SBTUITestTunnelServer registerCustomCommandNamed:@"myCustomCommandReturn123" block:^NSObject *(NSObject *object) {
         [[NSUserDefaults standardUserDefaults] setObject:object forKey:@"custom_command_test"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
 
         return @"123";
     }];
+
+    NSURL *url = [launchOptions valueForKey:UIApplicationLaunchOptionsURLKey];
+    if (url != nil) {
+        [[NSUserDefaults standardUserDefaults] setObject:url forKey:@"launch_url_test"];
+    }
+
     #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 14.0, *)) {
         [SBTUITestTunnelServer registerCustomCommandNamed:@"myCustomCommandReturnCLAccuracyAuth" block:^NSObject *(NSObject *object) {

--- a/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
@@ -240,4 +240,17 @@ class MiscellaneousTests: XCTestCase {
         
         XCTAssertFalse(app.scrollViews["scrollView"].buttons["Button"].isHittable)
     }
+
+    // Skipped due to bug with XCUIApplication.openURL: https://developer.apple.com/forums/thread/25355?answerId=755101022#755101022
+    func skipped_testOpenTunnelWithURL() throws {
+        guard #available(iOS 16.4, *) else {
+            throw XCTSkip("Unsupported iOS version")
+        }
+
+        let url = URL(string: "www.google.com")!
+        app.openTunnel(url: url)
+
+        let actualLaunchURL = app.userDefaultsObject(forKey: "launch_url_test") as! URL
+        XCTAssertEqual(url, actualLaunchURL)
+    }
 }

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -103,10 +103,26 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
 
 - (void)launchTunnel
 {
-    [self launchTunnelWithStartupBlock:nil];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunguarded-availability-new"
+    [self openTunnelWithURL:nil startupBlock:nil];
+#pragma GCC diagnostic pop
+}
+
+- (void)openTunnelWithURL:(NSURL *)url API_AVAILABLE(ios(16.4)) NS_SWIFT_NAME(openTunnel(url:));
+{
+    [self openTunnelWithURL:url startupBlock:nil];
 }
 
 - (void)launchTunnelWithStartupBlock:(void (^)(void))startupBlock
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunguarded-availability-new"
+    [self openTunnelWithURL:nil startupBlock:startupBlock];
+#pragma GCC diagnostic pop
+}
+
+- (void)openTunnelWithURL:(NSURL *)url startupBlock:(void (^)(void))startupBlock
 {
     NSAssert([NSThread isMainThread], @"This method should be invoked from main thread");
     
@@ -177,7 +193,7 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
         });
     }
     
-    [self.delegate tunnelClientIsReadyToLaunch:self];
+    [self.delegate tunnelClientIsReadyToLaunch:self url:url];
     
     while (YES) {
         [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];

--- a/Sources/SBTUITestTunnelClient/SBTUITunneledApplication.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITunneledApplication.m
@@ -36,18 +36,32 @@
 
 - (void)launchTunnelWithOptions:(NSArray<NSString *> *)options startupBlock:(void (^)(void))startupBlock
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunguarded-availability-new"
+    [self openTunnelWithURL:nil options:options startupBlock:startupBlock];
+#pragma GCC diagnostic pop
+}
+
+- (void)launchTunnelWithOptions:(NSArray<NSString *> *)options url:(NSURL *)url startupBlock:(void (^)(void))startupBlock
+{
     NSMutableArray *launchArguments = [self.launchArguments mutableCopy];
     [launchArguments addObjectsFromArray:options];
 
     self.launchArguments = launchArguments;
 
-    [self launchTunnelWithStartupBlock: startupBlock];
+    [self openTunnelWithURL:url startupBlock:startupBlock];
 }
 
 # pragma mark - SBTUITestTunnelClientDelegate
 
-- (void)tunnelClientIsReadyToLaunch:(SBTUITestTunnelClient *)sender
+- (void)tunnelClientIsReadyToLaunch:(SBTUITestTunnelClient *)sender url:(NSURL *)url
 {
+    if (@available(iOS 16.4, *)) {
+        if (url) {
+            [self openURL:url];
+            return;
+        }
+    }
     [self launch];
 }
 
@@ -65,9 +79,19 @@
     [self.client launchTunnel];
 }
 
+- (void)openTunnelWithURL:(NSURL *)url API_AVAILABLE(ios(16.4))
+{
+    [self.client openTunnelWithURL:url];
+}
+
 - (void)launchTunnelWithStartupBlock:(void (^)(void))startupBlock
 {
     [self.client launchTunnelWithStartupBlock:startupBlock];
+}
+
+- (void)openTunnelWithURL:(NSURL *)url startupBlock:(void (^)(void))startupBlock API_AVAILABLE(ios(16.4))
+{
+    [self.client openTunnelWithURL:url startupBlock:startupBlock];
 }
 
 - (void)launchConnectionless:(NSString * (^)(NSString *, NSDictionary<NSString *,NSString *> *))command

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClient.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClient.h
@@ -43,8 +43,9 @@ typedef enum: NSUInteger {
  It's required that you avoid launching until the delegate is called.
 
  @param sender An instance of the object sending the message.
+ @param url URL the app was launched with.
  */
-- (void)tunnelClientIsReadyToLaunch:(nonnull SBTUITestTunnelClient *)sender;
+- (void)tunnelClientIsReadyToLaunch:(nonnull SBTUITestTunnelClient *)sender url:(nullable NSURL *)url;
 @optional
 
 /**

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
@@ -30,6 +30,14 @@
 - (void)launchTunnel;
 
 /**
+ *  Launches the application synchronously using the provided URL waiting for
+ *  waiting for the tunnel server connection to be established.
+ *
+ *  @param url URL the app was launched with.
+ */
+- (void)openTunnelWithURL:(nullable NSURL *)url API_AVAILABLE(ios(16.4)) NS_SWIFT_NAME(openTunnel(url:));
+
+/**
  *  Launch application synchronously waiting for the tunnel server connection to be established.
  *
  *  @param startupBlock Block that is executed before connection is estabilished.
@@ -37,6 +45,17 @@
  *  Note: commands sent in the completionBlock will return nil
  */
 - (void)launchTunnelWithStartupBlock:(nullable void (^)(void))startupBlock;
+
+/**
+ *  Launches the application synchronously using the provided URL waiting for
+ *  waiting for the tunnel server connection to be established.
+ *
+ *  @param url URL the app was launched with.
+ *  @param startupBlock Block that is executed before connection is estabilished.
+ *  Useful to inject startup condition (user settings, preferences).
+ *  Note: commands sent in the completionBlock will return nil
+ */
+- (void)openTunnelWithURL:(nullable NSURL *)url startupBlock:(nullable void (^)(void))startupBlock API_AVAILABLE(ios(16.4)) NS_SWIFT_NAME(openTunnel(url:startupBlock:));
 
 /**
  *  Internal, don't use.

--- a/Sources/SBTUITestTunnelClient/include/SBTUITunneledApplication.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITunneledApplication.h
@@ -34,4 +34,20 @@
  */
 - (void)launchTunnelWithOptions:(nonnull NSArray<NSString *> *)options startupBlock:(nullable void (^)(void))startupBlock;
 
+/**
+ *  Launches the application synchronously using the provided URL waiting for
+ *  waiting for the tunnel server connection to be established.
+ *
+ *  @param options List of options to be passed on launch.
+ *  Valid options:
+ *  SBTUITunneledApplicationLaunchOptionResetFilesystem: delete app's filesystem sandbox
+ *  SBTUITunneledApplicationLaunchOptionDisableUITextFieldAutocomplete disables UITextField's autocomplete functionality which can lead to unexpected results when typing text.
+ * 
+ *  @param url URL the app was launched with.
+ *  @param startupBlock Block that is executed before connection is estabilished.
+ *  Useful to inject startup condition (user settings, preferences).
+ *  Note: commands sent in the completionBlock will return nil
+ */
+- (void)openTunnelWithURL:(nullable NSURL *)url options:(nonnull NSArray<NSString *> *)options startupBlock:(nullable void (^)(void))startupBlock NS_SWIFT_NAME(openTunnel(url:options:startupBlock:)) API_AVAILABLE(ios(16.4));
+
 @end


### PR DESCRIPTION
This PR adds support for launching the app with a URL, which allows for testing cold start deeplinks.