### PR TITLE
Fix pointer type mismatch

### DIFF
--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -338,12 +338,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
         
-        NSDictionary *result = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:objectData error:nil];
-        
-        return result ?: @{};
+        NSArray *result = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:objectData error:nil];
+
+        return result ?: @[];
     }
     
-    return @{};
+    return @[];
 }
 
 #pragma mark - Rewrite Commands

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
@@ -115,7 +115,7 @@
 /**
  *  Returns all active stubs
  *
- *  @return A dictionary containing all active stubs
+ *  @return An array containing all active stubs
  */
 - (nonnull NSArray<SBTActiveStub *> *)stubRequestsAll;
 

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -393,7 +393,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 {
     NSString *ret = nil;
     
-    NSDictionary *activeStubs = [SBTProxyURLProtocol stubRequestsAll];
+    NSArray *activeStubs = [SBTProxyURLProtocol stubRequestsAll];
     
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:activeStubs requiringSecureCoding:NO error:nil];
     if (data) {


### PR DESCRIPTION
Work towards #186.  

Fixes the types used in `stubRequestsAll` to be consistent:

> SBTUITestTunnelClient.m:343:16 Incompatible pointer types returning 'NSDictionary *' from a function with result type 'NSArray<SBTActiveStub *> * _Nonnull'