### PR TITLE
Adopt `NSSecureCoding` during deserialization

### DIFF
--- a/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
@@ -121,10 +121,10 @@ class MiscellaneousTests: XCTestCase {
 
         let monitoredRequests = app.monitoredRequestsFlushAll()
         XCTAssertEqual(monitoredRequests.count, 1)
-        let responsetHeaders = monitoredRequests.first?.response?.allHeaderFields
+        let responseHeaders = monitoredRequests.first?.response?.allHeaderFields
 
         XCTAssertEqual(networkString, "{\"hello\":\"there\"}\n")
-        XCTAssertEqual(responsetHeaders!["Content-Type"] as? String, "application/json")
+        XCTAssertEqual(responseHeaders?["Content-Type"] as? String, "application/json")
     }
 
     func testShutdown() {

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -338,12 +338,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
         
-        NSDictionary *result = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:objectData error:nil];
-        
-        return result ?: @{};
+        NSArray *result = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:objectData error:nil];
+
+        return result ?: @[];
     }
     
-    return @{};
+    return @[];
 }
 
 #pragma mark - Rewrite Commands

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -337,8 +337,11 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     NSString *objectBase64 = [self sendSynchronousRequestWithPath:SBTUITunneledApplicationCommandStubRequestsAll params:nil];
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
-        
-        NSArray *result = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:objectData error:nil];
+
+        NSError *unarchiveError;
+        NSSet *classes = [NSSet setWithObjects:[NSArray class], [SBTActiveStub class], nil];
+        NSArray *result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:objectData error:&unarchiveError];
+        NSAssert(unarchiveError == nil, @"Error unarchiving NSArray of SBTActiveStub");
 
         return result ?: @[];
     }
@@ -396,7 +399,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
         
-        return [NSKeyedUnarchiver unarchiveObjectWithData:objectData] ?: @[];
+        NSError *unarchiveError;
+        NSSet *classes = [NSSet setWithObjects:[NSArray class], [SBTMonitoredNetworkRequest class], nil];
+        NSArray *result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:objectData error:&unarchiveError];
+        NSAssert(unarchiveError == nil, @"Error unarchiving NSArray of SBTMonitoredNetworkRequest");
+
+        return result ?: @[];
     }
     
     return @[];
@@ -408,7 +416,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
         
-        return [NSKeyedUnarchiver unarchiveObjectWithData:objectData] ?: @[];
+        NSError *unarchiveError;
+        NSSet *classes = [NSSet setWithObjects:[NSArray class], [SBTMonitoredNetworkRequest class], nil];
+        NSArray *result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:objectData error:&unarchiveError];
+        NSAssert(unarchiveError == nil, @"Error unarchiving NSArray of SBTMonitoredNetworkRequest");
+
+        return result ?: @[];
     }
     
     return @[];
@@ -585,8 +598,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
-        
+
+        // this can't switch to the non-deprecated NSSecureCoding method because the types aren't known ahead of time
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return [NSKeyedUnarchiver unarchiveObjectWithData:objectData];
+        #pragma clang diagnostic pop
     }
     
     return nil;
@@ -608,7 +625,11 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
         
+        // this can't switch to the non-deprecated NSSecureCoding method because the types aren't known ahead of time
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return [NSKeyedUnarchiver unarchiveObjectWithData:objectData];
+        #pragma clang diagnostic pop
     }
     
     return nil;
@@ -642,8 +663,13 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     
     if (itemsBase64) {
         NSData *itemsData = [[NSData alloc] initWithBase64EncodedString:itemsBase64 options:0];
-        
-        return [NSKeyedUnarchiver unarchiveObjectWithData:itemsData];
+
+        NSError *unarchiveError;
+        NSSet *classes = [NSSet setWithObjects:[NSArray class], [NSData class], nil];
+        NSArray *result = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:itemsData error:&unarchiveError];
+        NSAssert(unarchiveError == nil, @"Error unarchiving NSArray of NSData");
+
+        return result;
     }
     
     return nil;
@@ -660,8 +686,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     
     if (objectBase64) {
         NSData *objectData = [[NSData alloc] initWithBase64EncodedString:objectBase64 options:0];
-        
+
+        // this can't switch to the non-deprecated NSSecureCoding method because the types aren't known ahead of time
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return [NSKeyedUnarchiver unarchiveObjectWithData:objectData];
+        #pragma clang diagnostic pop
     }
     
     return nil;

--- a/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
+++ b/Sources/SBTUITestTunnelClient/include/SBTUITestTunnelClientProtocol.h
@@ -115,7 +115,7 @@
 /**
  *  Returns all active stubs
  *
- *  @return A dictionary containing all active stubs
+ *  @return An array containing all active stubs
  */
 - (nonnull NSArray<SBTActiveStub *> *)stubRequestsAll;
 

--- a/Sources/SBTUITestTunnelCommon/SBTActiveStub.m
+++ b/Sources/SBTUITestTunnelCommon/SBTActiveStub.m
@@ -20,6 +20,10 @@
 
 @implementation SBTActiveStub : NSObject
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithMatch:(SBTRequestMatch *)match response:(SBTStubResponse *)response
 {
     if (self = [super init]) {
@@ -33,8 +37,8 @@
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
-        self.match = [decoder decodeObjectForKey:NSStringFromSelector(@selector(match))];
-        self.response = [decoder decodeObjectForKey:NSStringFromSelector(@selector(response))];
+        self.match = [decoder decodeObjectOfClass:[SBTRequestMatch class] forKey:NSStringFromSelector(@selector(match))];
+        self.response = [decoder decodeObjectOfClass:[SBTStubResponse class] forKey:NSStringFromSelector(@selector(response))];
     }
     
     return self;

--- a/Sources/SBTUITestTunnelCommon/SBTMonitoredNetworkRequest.m
+++ b/Sources/SBTUITestTunnelCommon/SBTMonitoredNetworkRequest.m
@@ -20,15 +20,19 @@
 
 @implementation SBTMonitoredNetworkRequest : NSObject
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
         self.timestamp = [decoder decodeDoubleForKey:NSStringFromSelector(@selector(timestamp))];
         self.requestTime = [decoder decodeDoubleForKey:NSStringFromSelector(@selector(requestTime))];
-        self.request = [decoder decodeObjectForKey:NSStringFromSelector(@selector(request))];
-        self.originalRequest = [decoder decodeObjectForKey:NSStringFromSelector(@selector(originalRequest))];
-        self.response = [decoder decodeObjectForKey:NSStringFromSelector(@selector(response))];
-        self.responseData = [decoder decodeObjectForKey:NSStringFromSelector(@selector(responseData))];
+        self.request = [decoder decodeObjectOfClass:[NSURLRequest class] forKey:NSStringFromSelector(@selector(request))];
+        self.originalRequest = [decoder decodeObjectOfClass:[NSURLRequest class] forKey:NSStringFromSelector(@selector(originalRequest))];
+        self.response = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSHTTPURLResponse class], [NSString class], [NSURLResponse class], nil] forKey:NSStringFromSelector(@selector(response))];
+        self.responseData = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(responseData))];
         self.isStubbed = [decoder decodeBoolForKey:NSStringFromSelector(@selector(isStubbed))];
         self.isRewritten = [decoder decodeBoolForKey:NSStringFromSelector(@selector(isRewritten))];
     }

--- a/Sources/SBTUITestTunnelCommon/SBTRequestMatch.m
+++ b/Sources/SBTUITestTunnelCommon/SBTRequestMatch.m
@@ -44,6 +44,10 @@
 
 @implementation SBTRequestMatch : NSObject
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithURL:(NSString *)url query:(NSArray<NSString *> *)query method:(NSString *)method body:(NSString *)body requestHeaders:(NSDictionary<NSString *,NSString *> *)requestHeaders responseHeaders:(NSDictionary<NSString *,NSString *> *)responseHeaders
 {
     if (self = [super init]) {
@@ -61,12 +65,14 @@
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
-        self.url = [decoder decodeObjectForKey:NSStringFromSelector(@selector(url))];
-        self.query = [decoder decodeObjectForKey:NSStringFromSelector(@selector(query))];
-        self.method = [decoder decodeObjectForKey:NSStringFromSelector(@selector(method))];
-        self.body = [decoder decodeObjectForKey:NSStringFromSelector(@selector(body))];
-        self.requestHeaders = [decoder decodeObjectForKey:NSStringFromSelector(@selector(requestHeaders))];
-        self.responseHeaders = [decoder decodeObjectForKey:NSStringFromSelector(@selector(responseHeaders))];
+        self.url = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(url))];
+        self.query = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSString class], nil] forKey:NSStringFromSelector(@selector(query))];
+        self.method = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(method))];
+        self.body = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(body))];
+
+        NSSet *dictClasses = [NSSet setWithObjects:[NSDictionary class], [NSString class], nil];
+        self.requestHeaders = [decoder decodeObjectOfClasses:dictClasses forKey:NSStringFromSelector(@selector(requestHeaders))];
+        self.responseHeaders = [decoder decodeObjectOfClasses:dictClasses forKey:NSStringFromSelector(@selector(responseHeaders))];
     }
     
     return self;

--- a/Sources/SBTUITestTunnelCommon/SBTRewrite.m
+++ b/Sources/SBTUITestTunnelCommon/SBTRewrite.m
@@ -19,6 +19,10 @@
 
 @implementation SBTRewrite : NSObject
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithUrlReplacement:(NSArray<SBTRewriteReplacement *> *)urlReplacement
                     requestReplacement:(NSArray<SBTRewriteReplacement *> *)requestReplacement
                    responseReplacement:(NSArray<SBTRewriteReplacement *> *)responseReplacement
@@ -43,11 +47,15 @@
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
-        self.urlReplacement = [decoder decodeObjectForKey:NSStringFromSelector(@selector(urlReplacement))];
-        self.requestReplacement = [decoder decodeObjectForKey:NSStringFromSelector(@selector(requestReplacement))];
-        self.responseReplacement = [decoder decodeObjectForKey:NSStringFromSelector(@selector(responseReplacement))];
-        self.requestHeadersReplacement = [decoder decodeObjectForKey:NSStringFromSelector(@selector(requestHeadersReplacement))];
-        self.responseHeadersReplacement = [decoder decodeObjectForKey:NSStringFromSelector(@selector(responseHeadersReplacement))];
+        NSSet *replacementClasses = [NSSet setWithObjects:[NSArray class], [SBTRewriteReplacement class], nil];
+        self.urlReplacement = [decoder decodeObjectOfClasses:replacementClasses forKey:NSStringFromSelector(@selector(urlReplacement))];
+        self.requestReplacement = [decoder decodeObjectOfClasses:replacementClasses forKey:NSStringFromSelector(@selector(requestReplacement))];
+        self.responseReplacement = [decoder decodeObjectOfClasses:replacementClasses forKey:NSStringFromSelector(@selector(responseReplacement))];
+
+        NSSet *dictClasses = [NSSet setWithObjects:[NSDictionary class], [NSString class], nil];
+        self.requestHeadersReplacement = [decoder decodeObjectOfClasses:dictClasses forKey:NSStringFromSelector(@selector(requestHeadersReplacement))];
+        self.responseHeadersReplacement = [decoder decodeObjectOfClasses:dictClasses forKey:NSStringFromSelector(@selector(responseHeadersReplacement))];
+        
         self.responseStatusCode = [decoder decodeIntForKey:NSStringFromSelector(@selector(responseStatusCode))];
         self.activeIterations = [decoder decodeIntForKey:NSStringFromSelector(@selector(activeIterations))];
     }

--- a/Sources/SBTUITestTunnelCommon/SBTRewriteReplacement.m
+++ b/Sources/SBTUITestTunnelCommon/SBTRewriteReplacement.m
@@ -25,6 +25,10 @@
 
 @implementation SBTRewriteReplacement : NSObject
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithFind:(NSString *)find replace:(NSString *)replace
 {
     if (self = [super init]) {
@@ -38,8 +42,8 @@
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
-        self.findData = [decoder decodeObjectForKey:NSStringFromSelector(@selector(findData))];
-        self.replaceData = [decoder decodeObjectForKey:NSStringFromSelector(@selector(replaceData))];
+        self.findData = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(findData))];
+        self.replaceData = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(replaceData))];
     }
     
     return self;

--- a/Sources/SBTUITestTunnelCommon/SBTStubFailureResponse.m
+++ b/Sources/SBTUITestTunnelCommon/SBTStubFailureResponse.m
@@ -18,6 +18,10 @@
 
 @implementation SBTStubFailureResponse
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (nonnull instancetype)initWithFailureCode:(NSInteger)failureCode
                                responseTime:(NSTimeInterval)responseTime
                            activeIterations:(NSInteger)activeIterations;

--- a/Sources/SBTUITestTunnelCommon/SBTStubResponse.m
+++ b/Sources/SBTUITestTunnelCommon/SBTStubResponse.m
@@ -58,6 +58,10 @@ NSString * const SBTResponseContentTypePdf = @"application/pdf";
 
 static SBTResponseDefaults *_defaults;
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithResponse:(NSObject *)response
                          headers:(NSDictionary<NSString *, NSString *> *)headers
                      contentType:(NSString *)contentType
@@ -166,9 +170,12 @@ static SBTResponseDefaults *_defaults;
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     if (self = [super init]) {
-        self.data = [decoder decodeObjectForKey:NSStringFromSelector(@selector(data))];
-        self.contentType = [decoder decodeObjectForKey:NSStringFromSelector(@selector(contentType))];
-        self.headers = [decoder decodeObjectForKey:NSStringFromSelector(@selector(headers))];
+        self.data = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(data))];
+        self.contentType = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(contentType))];
+
+        NSSet *dictClasses = [NSSet setWithObjects:[NSDictionary class], [NSString class], nil];
+        self.headers = [decoder decodeObjectOfClasses:dictClasses forKey:NSStringFromSelector(@selector(headers))];
+
         self.returnCode = [decoder decodeIntegerForKey:NSStringFromSelector(@selector(returnCode))];
         self.responseTime = [decoder decodeDoubleForKey:NSStringFromSelector(@selector(responseTime))];
         self.activeIterations = [decoder decodeIntegerForKey:NSStringFromSelector(@selector(activeIterations))];

--- a/Sources/SBTUITestTunnelCommon/include/SBTActiveStub.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTActiveStub.h
@@ -18,7 +18,7 @@
 
 @class SBTRequestMatch, SBTStubResponse;
 
-@interface SBTActiveStub: NSObject<NSCoding, NSCopying>
+@interface SBTActiveStub: NSObject<NSSecureCoding, NSCopying>
 
 /// The request match
 @property (nonnull, nonatomic, strong) SBTRequestMatch *match;

--- a/Sources/SBTUITestTunnelCommon/include/SBTMonitoredNetworkRequest.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTMonitoredNetworkRequest.h
@@ -18,7 +18,7 @@
 
 @class SBTRequestMatch;
 
-@interface SBTMonitoredNetworkRequest : NSObject<NSCoding>
+@interface SBTMonitoredNetworkRequest : NSObject<NSSecureCoding>
 
 - (nullable NSString *)responseString;
 - (nullable id)responseJSON;

--- a/Sources/SBTUITestTunnelCommon/include/SBTRequestMatch.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTRequestMatch.h
@@ -16,7 +16,7 @@
 
 @import Foundation;
 
-@interface SBTRequestMatch: NSObject<NSCoding, NSCopying>
+@interface SBTRequestMatch: NSObject<NSSecureCoding, NSCopying>
 
 /// A regex that is matched against the request url
 @property (nullable, nonatomic, strong) NSString *url;

--- a/Sources/SBTUITestTunnelCommon/include/SBTRewrite.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTRewrite.h
@@ -18,7 +18,7 @@
 
 @class SBTRewriteReplacement;
 
-@interface SBTRewrite: NSObject<NSCoding>
+@interface SBTRewrite: NSObject<NSSecureCoding>
 
 @property (nonnull, nonatomic, strong) NSArray<SBTRewriteReplacement *> *urlReplacement;
 @property (nonnull, nonatomic, strong) NSArray<SBTRewriteReplacement *> *requestReplacement;

--- a/Sources/SBTUITestTunnelCommon/include/SBTRewriteReplacement.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTRewriteReplacement.h
@@ -16,7 +16,7 @@
 
 @import Foundation;
 
-@interface SBTRewriteReplacement: NSObject<NSCoding, NSCopying>
+@interface SBTRewriteReplacement: NSObject<NSSecureCoding, NSCopying>
 
 /**
  *  Initializer

--- a/Sources/SBTUITestTunnelCommon/include/SBTStubResponse.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTStubResponse.h
@@ -16,7 +16,7 @@
 
 @import Foundation;
 
-@interface SBTStubResponse: NSObject<NSCoding, NSCopying>
+@interface SBTStubResponse: NSObject<NSSecureCoding, NSCopying>
 
 /// Set the default response time for all SBTStubResponses when not specified in intializer. If positive, the amount of time used to send the entire response. If negative, the rate in KB/s at which to send the response data. Use SBTUITunnelStubsDownloadSpeed* constants
 @property (class, nonatomic, assign) NSTimeInterval defaultResponseTime;

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -393,7 +393,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 {
     NSString *ret = nil;
     
-    NSDictionary *activeStubs = [SBTProxyURLProtocol stubRequestsAll];
+    NSArray *activeStubs = [SBTProxyURLProtocol stubRequestsAll];
     
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:activeStubs requiringSecureCoding:NO error:nil];
     if (data) {


### PR DESCRIPTION
Work towards #186.  Builds on #187.  

Adopts `NSSecureCoding` for serialization between client & server where the types are known at compile time.  The two notable exceptions are around `NSUserDefaults` and custom commands which both accept arbitrary input.