### PR TITLE
Fixes a CFNetwork runtime warning

### DIFF
--- a/Example/SBTUITestTunnel_Tests/CFNetworkMisuseTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CFNetworkMisuseTests.swift
@@ -1,0 +1,65 @@
+//
+//  CFNetworkMisuseTests.swift
+//  SBTUITestTunnel_Tests
+//
+
+import Foundation
+@testable import SBTUITestTunnelCommon
+import XCTest
+
+final class CFNetworkMisuseTests: XCTestCase {    
+    private let testURL = URL(string: "https://httpbin.org/post")!
+    private let testData = "this is a test".data(using: .utf8)
+
+    func testUploadTaskBodyHandling() throws {
+        let request = NSMutableURLRequest(url: testURL)
+        request.httpMethod = "POST"
+        request.httpBody = testData
+        
+        let task = URLSession.shared.uploadTask(with: request as URLRequest, from: testData) { _,_,_ in 
+            XCTFail("This test should not actually make a network request")
+        }
+        
+        // ensure that the request's original body is saved in NSURLProtocol but not set on the request itself
+        let originalRequest = try XCTUnwrap(task.originalRequest as? NSURLRequest)
+        XCTAssertNil(originalRequest.httpBody)
+        XCTAssertNil(originalRequest.httpBodyStream)
+        XCTAssertEqual(originalRequest.sbt_uploadHTTPBody(), testData)
+    }
+    
+    func testUploadTaskMarking() throws {
+        let request = NSMutableURLRequest(url: testURL)
+        request.httpMethod = "POST"
+        
+        let task = URLSession.shared.uploadTask(with: request as URLRequest, from: testData) { _,_,_ in 
+            XCTFail("This test should not actually make a network request")
+        }
+        
+        // ensure that the request is properly marked as an upload
+        let originalRequest = try XCTUnwrap(task.originalRequest as? NSURLRequest)
+        XCTAssertTrue(originalRequest.sbt_isUploadTaskRequest())
+    }
+    
+    func testDownloadTaskMarking() throws {
+        let request = NSMutableURLRequest(url: testURL)
+        request.httpMethod = "GET"
+        
+        let task = URLSession.shared.downloadTask(with: request as URLRequest) { _,_,_ in 
+            XCTFail("This test should not actually make a network request")
+        }
+        
+        // ensure that the request is not marked as an upload
+        let originalRequest = try XCTUnwrap(task.originalRequest as? NSURLRequest)
+        XCTAssertFalse(originalRequest.sbt_isUploadTaskRequest())
+    }
+    
+    func testUploadRequestBodyClearing() throws {
+        let request = NSMutableURLRequest(url: testURL)
+        request.httpBody = testData
+        
+        // ensure that the body fields didn't persist during the copy
+        let requestWithoutBody = try XCTUnwrap(request.sbt_copyWithoutBody() as? NSURLRequest)
+        XCTAssertNil(requestWithoutBody.httpBody)
+        XCTAssertNil(requestWithoutBody.httpBodyStream)
+    }
+}

--- a/Sources/SBTUITestTunnelCommon/private/NSURLRequest+HTTPBodyFix.h
+++ b/Sources/SBTUITestTunnelCommon/private/NSURLRequest+HTTPBodyFix.h
@@ -20,4 +20,18 @@
 
 @interface NSURLRequest (HTTPBodyFix)
 
+/// Determines if this request was originally associated with an upload task
+///
+/// When true, callers should use `sbt_uploadHTTPBody` to get the original body since `HTTPBody` will always be nil.
+- (BOOL)sbt_isUploadTaskRequest;
+
+/// Marks this request as associated with an upload task
+- (void)sbt_markUploadTaskRequest;
+
+/// Fetches an upload task's body from NSURLProtocol
+- (NSData*)sbt_uploadHTTPBody;
+
+/// Returns a copy of the request without the HTTP body
+- (NSURLRequest*)sbt_copyWithoutBody;
+
 @end

--- a/Sources/SBTUITestTunnelServer/private/NSURLSession+HTTPBodyFix.m
+++ b/Sources/SBTUITestTunnelServer/private/NSURLSession+HTTPBodyFix.m
@@ -22,32 +22,50 @@
 
 - (NSURLSessionUploadTask *)swz_uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData
 {
-    if ([request isKindOfClass:[NSMutableURLRequest class]] && bodyData) {
-        [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)request];
+    // remove the body to avoid a CFNetwork warning
+    NSURLRequest *requestWithoutBody = [request sbt_copyWithoutBody];
+
+    if ([requestWithoutBody isKindOfClass:[NSMutableURLRequest class]] && bodyData) {
+        [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)requestWithoutBody];
+
+        // mark this as an upload request so future code knows to find the body via NSURLProtocol instead
+        [requestWithoutBody sbt_markUploadTaskRequest];
     }
     
-    return [self swz_uploadTaskWithRequest:request fromData:bodyData];
+    return [self swz_uploadTaskWithRequest:requestWithoutBody fromData:bodyData];
 }
 
 - (NSURLSessionUploadTask *)swz_uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL
 {
-    if ([request isKindOfClass:[NSMutableURLRequest class]]) {
+    // remove the body to avoid a CFNetwork warning
+    NSURLRequest *requestWithoutBody = [request sbt_copyWithoutBody];
+
+    if ([requestWithoutBody isKindOfClass:[NSMutableURLRequest class]]) {
         NSData *bodyData = [NSData dataWithContentsOfURL:fileURL];
         if (bodyData) {
-            [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)request];
+            [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)requestWithoutBody];
+
+            // mark this as an upload request so future code knows to find the body via NSURLProtocol instead
+            [requestWithoutBody sbt_markUploadTaskRequest];
         }
     }
     
-    return [self swz_uploadTaskWithRequest:request fromFile:fileURL];
+    return [self swz_uploadTaskWithRequest:requestWithoutBody fromFile:fileURL];
 }
 
 - (NSURLSessionUploadTask *)swz_uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 {
-    if ([request isKindOfClass:[NSMutableURLRequest class]] && bodyData) {
-        [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)request];
+    // remove the body to avoid a CFNetwork warning
+    NSURLRequest *requestWithoutBody = [request sbt_copyWithoutBody];
+
+    if ([requestWithoutBody isKindOfClass:[NSMutableURLRequest class]] && bodyData) {
+        [NSURLProtocol setProperty:bodyData forKey:SBTUITunneledNSURLProtocolHTTPBodyKey inRequest:(NSMutableURLRequest *)requestWithoutBody];
+
+        // mark this as an upload request so future code knows to find the body via NSURLProtocol instead
+        [requestWithoutBody sbt_markUploadTaskRequest];
     }
-    
-    return [self swz_uploadTaskWithRequest:request fromData:bodyData completionHandler:completionHandler];
+
+    return [self swz_uploadTaskWithRequest:requestWithoutBody fromData:bodyData completionHandler:completionHandler];
 }
 
 - (NSURLSessionUploadTask *)swz_uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;


### PR DESCRIPTION
Work towards https://github.com/Subito-it/SBTUITestTunnel/issues/186.

In Xcode 15+ CFNetwork emits a runtime warning when an upload task contains a body:

> The request of a upload task should not contain a body or a body stream, use `upload(for:fromFile:)`,`upload(for:from:)`, or supply the body stream through the `urlSession(_:needNewBodyStreamForTask:)` delegate method.

To work around this, we keep track of requests originating from upload tasks with the existing swizzling in `NSURLSession+HTTPBodyFix`.  For those tasks, we save the original body via NSURLProtocol and remove it from the request to avoid the warning.

When using a request body (e.g., when matching stubs), previously marked upload requests _must_ exclusively reference the copy from NSURLProtocol because the request's `HTTPBody` was cleared.