### PR TITLE
Fixes an NSURLProtocol runtime warning for `didReceiveResponse`

### DIFF
--- a/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
+++ b/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
@@ -672,8 +672,6 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
             [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
             [self.client URLProtocol:self didLoadData:stubResponse.data];
             [self.client URLProtocolDidFinishLoading:self];
-            
-            return;
         } else {
             [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
         }


### PR DESCRIPTION
Work towards https://github.com/Subito-it/SBTUITestTunnel/issues/186.

Fixes case where `URLSession:dataTask:didReceiveResponse:` could sometimes return without calling its completion handler:

> API MISUSE: dataTask:didReceiveResponse:completionHandler: completion handler not called