### PR TITLE
Fix threading issue in IPC connection

### DIFF
--- a/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.h
+++ b/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.h
@@ -76,6 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Invalidate the connection. All outstanding error handling blocks will be called on the message handling queue. The connection must be invalidated before it is deallocated. After a connection is invalidated, no more messages may be sent or received.
 - (void)invalidate;
 
+- (BOOL)isValid;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This change addresses the possibility of
`DTXIPCConnection._slaveDidConnectWithName` being called from non-main thread by dispatching the work to main thread when it is being called from non main thread. This is necessary so that `_otherConnection` gets assigned on main thread.

`SBTUITestTunnelClient.serverDidConnect` is updated to wait for `ipcConnection` to become valid. This is needed because `DTXIPCConnection._slaveDidConnectWithName` and `SBTUITestTunnelClient.serverDidConnect` can be called from different threads upon which we dispatch both to main. But `SBTUITestTunnelClient.serverDidConnect` work can start first at which point it can lead to assertion of `ipcConnection` not being valid as `ipcConnection._otherConnection` has not yet been assigned.

---

These threading issues can result in following assertion:
```
Thread 1: "[SBTUITestTunnelClient] Failed getting IPC proxy, Error Domain=DTXIPCErrorDomain Code=1 \"Connection <DTXIPCConnection: 0x60000265b9c0> is invalid.\" UserInfo={NSLocalizedDescription=Connection <DTXIPCConnection: 0x60000265b9c0> is invalid.}"
```

In order to debug this issue, I added bunch of NSLogs to the codebase (https://github.com/alvar-bolt/SBTUITestTunnel/commit/e96bbc4f948918ddde6e9532d4e105f4cd331f67#diff-313307a5a8b84223b5eb7add983e43794ab1c14ea722485ed889152e5519b725R326).

From there, I ran a test that called `app.userDefaultsObject` immediately after tunnel was launched successfully. This is important as it ends up calling `-[_DTXIPCDistantObject forwardInvocation:]` **on main thread** which in turn calls `_connection.isValid` which is:
```objc
- (BOOL)isValid
{
	return _connection.isValid && _otherConnection.isValid;
}
```
Important part of that code is access of `_otherConnection`. As current bug allows writing of it from different thread, then we cannot be sure that it is set.

In our codebase is was able to find a test case where `_slaveDidConnectWithName` was called on non main thread in ~25% of the cases. Luckily I was also able to observe that behaviour in `SBTUITestTunnel_Tests.MiscellaneousTests.testCustomCommand()`, although there it happens in ~1% of the cases.

This behaviour does not always lead to assertion as there is still possibility that `_otherConnection` gets stored before it is being accessed from main thread. But if you are unlucky enough, it is still in progress and so, the `isValid` check will fail.

<details>
<summary>Example of _slaveDidConnectWithName</summary>

![Screenshot 2024-05-15 at 09 56 24](https://github.com/Subito-it/SBTUITestTunnel/assets/72379847/972582fe-a1c8-4dd5-965e-85543904af71)

</details>