### PR TITLE
Resolve ipc race condition

### DIFF
--- a/Example/SBTUITestTunnel_Tests/Info.plist
+++ b/Example/SBTUITestTunnel_Tests/Info.plist
@@ -21,6 +21,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>SBTUITestTunnelDisableIPC</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -249,6 +249,15 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
 
 - (void)serverDidConnect:(id)sender
 {
+    while (!self.ipcConnection.isValid) {
+        if (CFAbsoluteTimeGetCurrent() - self.launchStart > SBTUITunneledApplicationDefaultTimeout) {
+            [self shutDownWithErrorMessage:@"[SBTUITestTunnel] IPC tunnel did fail to connect" code:SBTUITestTunnelErrorConnectionToApplicationFailed];
+            return;
+        }
+            
+        [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+    }
+    
     __weak typeof(self)weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         weakSelf.connected = YES;

--- a/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.h
+++ b/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.h
@@ -76,6 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Invalidate the connection. All outstanding error handling blocks will be called on the message handling queue. The connection must be invalidated before it is deallocated. After a connection is invalidated, no more messages may be sent or received.
 - (void)invalidate;
 
+- (BOOL)isValid;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -157,6 +157,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 - (BOOL)takeOffOnceIPCWithServiceIdentifier:(NSString *)serviceIdentifier
 {
     self.ipcConnection = [[DTXIPCConnection alloc] initWithServiceName:[NSString stringWithFormat:@"com.subito.sbtuitesttunnel.ipc.%@", serviceIdentifier]];
+    
     self.ipcConnection.remoteObjectInterface = [DTXIPCInterface interfaceWithProtocol:@protocol(SBTIPCTunnel)];
     self.ipcConnection.exportedInterface = [DTXIPCInterface interfaceWithProtocol:@protocol(SBTIPCTunnel)];
     self.ipcConnection.exportedObject = self;


### PR DESCRIPTION
These changes take try to address the race condition highlighted in #210 using a dedicated queue to protect the `_otherConnection` property.