### PR TITLE
request data for uploading task

### DIFF
--- a/Sources/SBTUITestTunnelCommon/SBTMonitoredNetworkRequest.m
+++ b/Sources/SBTUITestTunnelCommon/SBTMonitoredNetworkRequest.m
@@ -37,6 +37,7 @@
         self.responseData = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(responseData))];
         self.isStubbed = [decoder decodeBoolForKey:NSStringFromSelector(@selector(isStubbed))];
         self.isRewritten = [decoder decodeBoolForKey:NSStringFromSelector(@selector(isRewritten))];
+        self.requestData = [decoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(requestData))];
     }
     
     return self;
@@ -57,6 +58,7 @@
     
     [encoder encodeObject:self.response forKey:NSStringFromSelector(@selector(response))];
     [encoder encodeObject:self.responseData forKey:NSStringFromSelector(@selector(responseData))];
+    [encoder encodeObject:self.requestData forKey:NSStringFromSelector(@selector(requestData))];
     [encoder encodeBool:self.isStubbed forKey:NSStringFromSelector(@selector(isStubbed))];
     [encoder encodeBool:self.isRewritten forKey:NSStringFromSelector(@selector(isRewritten))];
 }

--- a/Sources/SBTUITestTunnelCommon/include/SBTMonitoredNetworkRequest.h
+++ b/Sources/SBTUITestTunnelCommon/include/SBTMonitoredNetworkRequest.h
@@ -36,6 +36,7 @@
 @property (nullable, nonatomic, strong) NSHTTPURLResponse *response;
 
 @property (nullable, nonatomic, strong) NSData *responseData;
+@property (nullable, nonatomic, strong) NSData *requestData;
 
 @property (nonatomic, assign) BOOL isStubbed;
 @property (nonatomic, assign) BOOL isRewritten;

--- a/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
+++ b/Sources/SBTUITestTunnelServer/private/SBTProxyURLProtocol.m
@@ -432,6 +432,10 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
                 monitoredRequest.isStubbed = YES;
                 monitoredRequest.isRewritten = NO;
                 
+                NSData *bodyData = ([monitoredRequest.originalRequest sbt_isUploadTaskRequest]) ? [monitoredRequest.originalRequest sbt_uploadHTTPBody] : monitoredRequest.originalRequest.HTTPBody;
+                
+                monitoredRequest.requestData = bodyData;
+                
                 dispatch_sync([SBTProxyURLProtocol sharedInstance].monitoredRequestsSyncQueue, ^{
                     [[SBTProxyURLProtocol sharedInstance].monitoredRequests addObject:monitoredRequest];
                 });
@@ -602,6 +606,10 @@ typedef void(^SBTStubUpdateBlock)(NSURLRequest *request);
         
         monitoredRequest.isStubbed = NO;
         monitoredRequest.isRewritten = isRequestRewritten;
+        
+        NSData *bodyData = ([monitoredRequest.originalRequest sbt_isUploadTaskRequest]) ? [monitoredRequest.originalRequest sbt_uploadHTTPBody] : monitoredRequest.originalRequest.HTTPBody;
+        
+        monitoredRequest.requestData = bodyData;
         
         dispatch_sync([SBTProxyURLProtocol sharedInstance].monitoredRequestsSyncQueue, ^{
             [[SBTProxyURLProtocol sharedInstance].monitoredRequests addObject:monitoredRequest];


### PR DESCRIPTION
Since [Fixes a CFNetwork runtime warning](https://github.com/Subito-it/SBTUITestTunnel/pull/191) there is no way to get http body for uploadTasks from `monitoredRequests`, it's always swizzled to nil.
Here is workaround, new `requestData` property in `monitoredRequests` which store request http body even for uploadTasks.
