### PR TITLE
Reserve HTTP server port

### DIFF
--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -1083,7 +1083,12 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
             continue;
         }
 
-        // Put the port in the TIME_WAIT state, to temporarily reserve it
+        // Attempt to reserve the port by putting it in TIME_WAIT state. During this time,
+        // the system prevents other applications from binding to the same port,
+        // to prevent packets meant for the recently closed connection from being
+        // misdirected to the new application. Since SBTWebServer is utilizing SO_REUSEADDR on the
+        // server socket, we can bind to the port even though it's in TIME_WAIT state,
+        // effectively reserving it for our own use until we close the server socket.
         if (listen(server_sock, 1)) {
             close(server_sock);
             return -4;

--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -1062,26 +1062,60 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
         addr.sin_family = AF_INET;
         addr.sin_port = 0;
         inet_aton("0.0.0.0", &addr.sin_addr);
-        int sock = socket(AF_INET, SOCK_STREAM, 0);
-        if (sock < 0) {
+        int server_sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (server_sock < 0) {
             return -1;
         }
-        if (bind(sock, (struct sockaddr*) &addr, sizeof(addr)) != 0) {
+        if (bind(server_sock, (struct sockaddr*) &addr, sizeof(addr)) != 0) {
+            close(server_sock);
             return -2;
         }
-        if (getsockname(sock, (struct sockaddr*) &addr, &len) != 0) {
+        if (getsockname(server_sock, (struct sockaddr*) &addr, &len) != 0) {
+            close(server_sock);
             return -3;
         }
-        
-        if (addr.sin_port > 1023) {
-            return addr.sin_port;
-        } else {
+
+        in_port_t port = addr.sin_port;
+
+        if (port <= 1023) {
+            close(server_sock);
             NSLog(@"[SBTUITestTunnel] Invalid port assigned, trying again");
-            close(sock);
+            continue;
         }
+
+        // Put the port in the TIME_WAIT state, to temporarily reserve it
+        if (listen(server_sock, 1)) {
+            close(server_sock);
+            return -4;
+        }
+
+        int client_sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (client_sock < 0) {
+            close(server_sock);
+            return -5;
+        }
+
+        if (connect(client_sock, (struct sockaddr*) &addr, sizeof(addr))) {
+            close(server_sock);
+            close(client_sock);
+            return -6;
+        }
+
+        int accept_sock = accept(server_sock, nil, nil);
+        if (accept_sock < 0) {
+            close(server_sock);
+            close(client_sock);
+            return -7;
+        }
+
+        close(server_sock);
+        close(client_sock);
+        close(accept_sock);
+
+        return port;
     }
 
-    return -4;
+    return -8;
 }
 
 #pragma mark - Error Helpers


### PR DESCRIPTION
Ciao,
we've been relying on SBTUITestTunnel to UI tests a fairly large codebase with 2k+ UI tests.
When running tests in parallel on multiple simulators (4+) with IPC disabled, we've been encountering failures due to UITestTunnelServer being unable to bind to the HTTP server address:

> [UITestTunnelServer] Failed to start server on port 61692. Error Domain=NSPOSIXErrorDomain Code=48 "Address already in use" UserInfo={NSLocalizedDescription=Address already in use}

Through debugging I've identified a potential race in `[SBTUITestTunnelClient findOpenPort]` which can lead to the system allocating the same port in parallel processes, leading to the aforementioned error.

In this PR I've refactored `findOpenPort` to temporarily "reserve" the port which should prevent the system from allocating it to other processes for a certain time frame (hopefully long enough to start the server and bind the address)