### PR TITLE
Fix NOOP code in DTXIPCConnection when assertions are turned off.

### DIFF
--- a/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.m
+++ b/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.m
@@ -235,7 +235,8 @@ static dispatch_queue_t _connectionQueue;
 			_slave = YES;
 			
 			//Attempt becoming the slave
-			NSAssert([self _commonInit] == YES, @"The service “%@” already has two endpoints connected.", _serviceName);
+            BOOL initResult = [self _commonInit];
+			NSAssert(initResult == YES, @"The service “%@” already has two endpoints connected.", _serviceName);
 			
 			_otherConnection = [NSConnection connectionWithRegisteredName:_serviceName host:nil];
 			[NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_otherConnectionDidDie:) name:NSConnectionDidDieNotification object:_otherConnection];


### PR DESCRIPTION
When SBTUITestTunnel configures an IPC connection (DTXIPCConnection.m) it performs its initialisation within a NSAssert:

`NSAssert([self _commonInit] == YES, @"The service “%@” already has two endpoints connected.", _serviceName);`

In Release configurations NS assertions are disabled, and when they're disabled NSAssert becomes a no-op,
which means the init code is missing from Release builds and UI tests always fail to launch if IPC is enabled.
