### PR TITLE
Makes swizzled CLLocationManager to follow Apple contract on Threading 

### DIFF
--- a/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionCoreLocationViewController.swift
@@ -17,17 +17,37 @@
 import CoreLocation
 import UIKit
 
+class MainThreadSBTExtensionCoreLocationViewController: SBTExtensionCoreLocationViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        locationManager = CLLocationManager()
+        locationManager?.delegate = self
+    }
+}
+
+class BackgroundThreadSBTExtensionCoreLocationViewController: SBTExtensionCoreLocationViewController {
+    private let workerThread = SBUITestThread()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        workerThread.start { [weak self] in
+            guard let self else { return }
+            self.locationManager = CLLocationManager()
+            self.locationManager?.delegate = self
+        }
+    }
+}
+
 class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManagerDelegate {
-    private let authorizationButton = UIButton()
-    private let updateLocationButton = UIButton()
-    private let stopLocationUpdateButton = UIButton()
-    private let currentLocationButton = UIButton()
-    private let statusLabel = UILabel()
-    private let statusThreadLabel = UILabel()
-    private let locationLabel = UILabel()
-    private let locationThreadLabel = UILabel()
-    private let currentLocationLabel = UILabel()
-    private let locationManager = CLLocationManager()
+    fileprivate let authorizationButton = UIButton()
+    fileprivate let updateLocationButton = UIButton()
+    fileprivate let stopLocationUpdateButton = UIButton()
+    fileprivate let currentLocationButton = UIButton()
+    fileprivate let statusLabel = UILabel()
+    fileprivate let statusThreadLabel = UILabel()
+    fileprivate let locationLabel = UILabel()
+    fileprivate let locationThreadLabel = UILabel()
+    fileprivate let currentLocationLabel = UILabel()
+    fileprivate var locationManager: CLLocationManager?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -86,27 +106,26 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
             contentStack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
         ])
 
-        locationManager.delegate = self
     }
 
     @objc func updateTapped(_: Any) {
-        locationManager.startUpdatingLocation()
+        locationManager?.startUpdatingLocation()
     }
 
     @objc func stopTapped(_: Any) {
-        locationManager.stopUpdatingLocation()
+        locationManager?.stopUpdatingLocation()
     }
 
     @objc func authorizationStatusTapped(_: Any) {
         if #available(iOS 14.0, *) {
-            statusLabel.text = "\(locationManager.authorizationStatus.description)"
+            statusLabel.text = "\(locationManager?.authorizationStatus.description ?? "nil")"
         } else {
             statusLabel.text = "\(CLLocationManager.authorizationStatus().description)"
         }
     }
 
     @objc func currentLocationTapped(_: Any) {
-        if let location = locationManager.location {
+        if let location = locationManager?.location {
             currentLocationLabel.text = "\(location.coordinate.latitude) \(location.coordinate.longitude)"
         } else {
             currentLocationLabel.text = "nil"
@@ -115,9 +134,10 @@ class SBTExtensionCoreLocationViewController: UIViewController, CLLocationManage
 }
 
 @available(iOS 14.0, *)
-extension SBTExtensionCoreLocationViewController {
+extension BackgroundThreadSBTExtensionCoreLocationViewController {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == workerThread.thread)
         DispatchQueue.main.async { [weak self] in
             self?.statusLabel.text = manager.authorizationStatus.description
             self?.statusThreadLabel.text = threadName
@@ -125,9 +145,10 @@ extension SBTExtensionCoreLocationViewController {
     }
 }
 
-extension SBTExtensionCoreLocationViewController {
+extension BackgroundThreadSBTExtensionCoreLocationViewController {
     func locationManager(_: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == workerThread.thread)
         if #unavailable(iOS 14.0) {
             DispatchQueue.main.async { [weak self] in
                 self?.statusLabel.text = status.description
@@ -137,9 +158,46 @@ extension SBTExtensionCoreLocationViewController {
     }
 }
 
-extension SBTExtensionCoreLocationViewController {
+extension BackgroundThreadSBTExtensionCoreLocationViewController {
     func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == workerThread.thread)
+        DispatchQueue.main.async { [weak self] in
+            self?.locationLabel.text = locations.map { "\($0.coordinate.latitude) \($0.coordinate.longitude)" }.joined(separator: "+")
+            self?.locationThreadLabel.text = threadName
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+extension MainThreadSBTExtensionCoreLocationViewController {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == Thread.main)
+        DispatchQueue.main.async { [weak self] in
+            self?.statusLabel.text = manager.authorizationStatus.description
+            self?.statusThreadLabel.text = threadName
+        }
+    }
+}
+
+extension MainThreadSBTExtensionCoreLocationViewController {
+    func locationManager(_: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == Thread.main)
+        if #unavailable(iOS 14.0) {
+            DispatchQueue.main.async { [weak self] in
+                self?.statusLabel.text = status.description
+                self?.statusThreadLabel.text = threadName
+            }
+        }
+    }
+}
+
+extension MainThreadSBTExtensionCoreLocationViewController {
+    func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        let threadName = Thread.isMainThread ? "Main" : "Not main"
+        assert(Thread.current == Thread.main)
         DispatchQueue.main.async { [weak self] in
             self?.locationLabel.text = locations.map { "\($0.coordinate.latitude) \($0.coordinate.longitude)" }.joined(separator: "+")
             self?.locationThreadLabel.text = threadName

--- a/Example/SBTUITestTunnel/SBTTableViewController.swift
+++ b/Example/SBTUITestTunnel/SBTTableViewController.swift
@@ -62,7 +62,8 @@ class SBTTableViewController: UITableViewController {
                                         Extension1Test(testSelector: #selector(showExtensionTable1)),
                                         Extension2Test(testSelector: #selector(showExtensionTable2)),
                                         Extension3Test(testSelector: #selector(showExtensionScrollView)),
-                                        Extension4Test(testSelector: #selector(showCoreLocationViewController)),
+                                        Extension4Test(testSelector: #selector(showMainThreadCoreLocationViewController)),
+                                        Extension4Test(testSelector: #selector(showBackgroundThreadCoreLocationViewController)),
                                         Extension5Test(testSelector: #selector(showExtensionCollectionViewVertical)),
                                         Extension6Test(testSelector: #selector(showExtensionCollectionViewHorizontal)),
                                         CrashTest(testSelector: #selector(crashApp))]
@@ -434,8 +435,13 @@ extension SBTTableViewController {
 }
 
 extension SBTTableViewController {
-    @objc func showCoreLocationViewController() {
-        let targetViewController = SBTExtensionCoreLocationViewController()
+    @objc func showMainThreadCoreLocationViewController() {
+        let targetViewController = MainThreadSBTExtensionCoreLocationViewController()
+        navigationController?.pushViewController(targetViewController, animated: true)
+    }
+
+    @objc func showBackgroundThreadCoreLocationViewController() {
+        let targetViewController = BackgroundThreadSBTExtensionCoreLocationViewController()
         navigationController?.pushViewController(targetViewController, animated: true)
     }
 }

--- a/Example/SBTUITestTunnel/SBUITestThread.swift
+++ b/Example/SBTUITestTunnel/SBUITestThread.swift
@@ -1,0 +1,63 @@
+//
+//  Thread.swift
+//  SBTUITestTunnel
+//
+//  Created by Rinat Enikeev on 10.02.2026.
+//
+
+import Foundation
+
+open class SBUITestThread: NSObject {
+    public var thread: Thread!
+    private var block: (() -> Void)?
+
+    override public init() {}
+
+    @objc func runBlock() {
+        autoreleasepool {
+            block?()
+        }
+    }
+
+    open func start(_ block: @escaping () -> Void) {
+        self.block = block
+
+        let threadName = String(describing: self)
+            .components(separatedBy: .punctuationCharacters)[1]
+
+        thread = Thread { [weak self] in
+            defer { self?.block = nil }
+            while !(self?.thread.isCancelled ?? true) {
+                RunLoop.current.run(
+                    mode: RunLoop.Mode.default,
+                    before: Date.distantFuture
+                )
+            }
+        }
+        thread.name = "\(threadName)-\(UUID().uuidString)"
+        thread.start()
+
+        perform(
+            #selector(runBlock),
+            on: thread,
+            with: nil,
+            waitUntilDone: false,
+            modes: [RunLoop.Mode.default.rawValue]
+        )
+    }
+
+    public func stopWork() {
+        block = nil
+        perform(
+            #selector(stopThread),
+            on: thread,
+            with: nil,
+            waitUntilDone: false,
+            modes: [RunLoop.Mode.default.rawValue]
+        )
+    }
+
+    @objc func stopThread() {
+        thread.cancel()
+    }
+}

--- a/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
+++ b/Example/SBTUITestTunnel_Tests/CoreLocationTests.swift
@@ -11,12 +11,12 @@ import SBTUITestTunnelClient
 import XCTest
 
 class CoreLocationTests: XCTestCase {
-    func testCoreLocationStubAuthorizationStatus() {
+    func testMainThreadCoreLocationStubAuthorizationStatus() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
         wait { self.app.staticTexts["location_status"].label == "authorizedAlways" }
 
         app.coreLocationStubAuthorizationStatus(.notDetermined)
@@ -40,13 +40,42 @@ class CoreLocationTests: XCTestCase {
         wait { self.app.staticTexts["location_status"].label == "authorizedAlways" }
     }
 
-    func testCoreLocationUpdate() {
+    func testBackgroundThreadCoreLocationStubAuthorizationStatus() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+        wait { self.app.staticTexts["location_status"].label == "authorizedAlways" }
+
+        app.coreLocationStubAuthorizationStatus(.notDetermined)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .notDetermined)
+        wait { self.app.staticTexts["location_status"].label == "notDetermined" }
+
+        app.coreLocationStubAuthorizationStatus(.denied)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .denied)
+        wait { self.app.staticTexts["location_status"].label == "denied" }
+
+        app.coreLocationStubAuthorizationStatus(.restricted)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .restricted)
+        wait { self.app.staticTexts["location_status"].label == "restricted" }
+
+        app.coreLocationStubAuthorizationStatus(.authorizedWhenInUse)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedWhenInUse)
+        wait { self.app.staticTexts["location_status"].label == "authorizedWhenInUse" }
+
+        app.coreLocationStubAuthorizationStatus(.authorizedAlways)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+        wait { self.app.staticTexts["location_status"].label == "authorizedAlways" }
+    }
+
+    func testMainThreadCoreLocationUpdate() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
         app.buttons["Update location"].tap()
 
         app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
@@ -60,13 +89,33 @@ class CoreLocationTests: XCTestCase {
         app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
     }
 
-    func testCoreLocationStopAndResume() {
+    func testBackgroundThreadCoreLocationUpdate() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
         XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+        app.buttons["Update location"].tap()
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+
+        wait { self.app.staticTexts["location_pos"].label == "44.0 11.1" }
+
+        app.navigationBars.buttons.firstMatch.tap()
+
+        Thread.sleep(forTimeInterval: 2.0)
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+    }
+
+    func testMainThreadCoreLocationStopAndResume() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
         app.buttons["Update location"].tap()
 
         app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
@@ -90,12 +139,42 @@ class CoreLocationTests: XCTestCase {
         }
     }
 
-    func testCoreLocationUpdateRespectsAuthorizationStatus() {
+    func testBackgroundThreadCoreLocationStopAndResume() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+        XCTAssertEqual(getStubbedCoreLocationAuthorizationStatus(), .authorizedAlways)
+
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+        app.buttons["Update location"].tap()
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+
+        wait { self.app.staticTexts["location_pos"].label == "44.0 11.1" }
+        wait { self.app.staticTexts["location_thread"].label == "Not main" }
+
+        app.buttons["Stop location updates"].tap()
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 0.0, longitude: 0.0)])
+        Thread.sleep(forTimeInterval: 2.0)
+        wait { self.app.staticTexts["location_pos"].label == "44.0 11.1" }
+        wait { self.app.staticTexts["location_thread"].label == "Not main" }
+
+        app.buttons["Update location"].tap()
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 11.1, longitude: 44.0)])
+
+        wait(withTimeout: 2) {
+            self.app.staticTexts["location_pos"].label == "11.1 44.0" &&
+                self.app.staticTexts["location_thread"].label == "Not main"
+        }
+    }
+
+    func testMainThreadCoreLocationUpdateRespectsAuthorizationStatus() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
         app.buttons["Update location"].tap()
 
         XCTContext.runActivity(named: "Without authorization no location update should occurr") { _ in
@@ -126,12 +205,48 @@ class CoreLocationTests: XCTestCase {
         }
     }
 
-    func testCoreLocationManagerLocationRespectsAuthorizationStatus() {
+    func testBackgroundThreadCoreLocationUpdateRespectsAuthorizationStatus() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+        app.buttons["Update location"].tap()
+
+        XCTContext.runActivity(named: "Without authorization no location update should occurr") { _ in
+            for status in [CLAuthorizationStatus.notDetermined, .denied, .notDetermined, .restricted] {
+                app.coreLocationStubAuthorizationStatus(status)
+                app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+                Thread.sleep(forTimeInterval: 1.0)
+                XCTAssertEqual(app.staticTexts["location_pos"].label, "-", "Unexpected update with status \(status)")
+                XCTAssertEqual(app.staticTexts["location_status_thread"].label, "Not main", "Unexpected status update on main thread")
+            }
+        }
+
+        XCTContext.runActivity(named: "With authorization location update should occurr") { _ in
+            var statusIndex = 0.0
+            for status in [CLAuthorizationStatus.authorizedAlways, .authorizedWhenInUse] {
+                app.coreLocationStubAuthorizationStatus(status)
+                app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1 + statusIndex)])
+
+                wait(withTimeout: 2) {
+                    self.app.staticTexts["location_pos"].label == "44.0 \(11.1 + statusIndex)"
+                }
+
+                XCTAssertEqual(app.staticTexts["location_thread"].label, "Not main", "Unexpected location update on main thread")
+                XCTAssertEqual(app.staticTexts["location_status_thread"].label, "Not main", "Unexpected status update on main thread")
+
+                statusIndex += 1.0
+            }
+        }
+    }
+
+    func testMainThreadCoreLocationManagerLocationRespectsAuthorizationStatus() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
 
         XCTContext.runActivity(named: "Without authorization no location update should be returned") { _ in
             for status in [CLAuthorizationStatus.notDetermined, .denied, .notDetermined, .restricted] {
@@ -183,13 +298,92 @@ class CoreLocationTests: XCTestCase {
         }
     }
 
-    func testCoreLocationManagerLocationGetsUpdatedOnLocationUpdates() {
+    func testBackgroundThreadCoreLocationManagerLocationRespectsAuthorizationStatus() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+
+        XCTContext.runActivity(named: "Without authorization no location update should be returned") { _ in
+            for status in [CLAuthorizationStatus.notDetermined, .denied, .notDetermined, .restricted] {
+                app.coreLocationStubAuthorizationStatus(status)
+
+                app.buttons["Get manager current location"].tap()
+
+                Thread.sleep(forTimeInterval: 1.0)
+                XCTAssertEqual(app.staticTexts["manager_location"].label, "nil", "Unexpected location with status \(status)")
+            }
+        }
+
+        XCTContext.runActivity(named: "With authorization location update should occurr") { _ in
+            var statusIndex = 0.0
+            for status in [CLAuthorizationStatus.authorizedAlways, .authorizedWhenInUse] {
+                app.coreLocationStubAuthorizationStatus(status)
+                app.coreLocationStubManagerLocation(CLLocation(latitude: 44.0, longitude: 11.1 + statusIndex))
+
+                app.buttons["Get manager current location"].tap()
+
+                wait(withTimeout: 2) {
+                    self.app.staticTexts["manager_location"].label == "44.0 \(11.1 + statusIndex)"
+                }
+
+                statusIndex += 1.0
+            }
+        }
+
+        XCTContext.runActivity(named: "Check that nil location is supported") { _ in
+            app.coreLocationStubAuthorizationStatus(.authorizedAlways)
+            app.coreLocationStubManagerLocation(nil)
+
+            app.buttons["Get manager current location"].tap()
+
+            wait(withTimeout: 2) {
+                self.app.staticTexts["manager_location"].label == "nil"
+            }
+        }
+
+        XCTContext.runActivity(named: "Check that non nil location updates") { _ in
+            app.coreLocationStubAuthorizationStatus(.authorizedAlways)
+            app.coreLocationStubManagerLocation(CLLocation(latitude: 44.0, longitude: 11.1))
+
+            app.buttons["Get manager current location"].tap()
+
+            wait(withTimeout: 2) {
+                self.app.staticTexts["manager_location"].label == "44.0 \(11.1)"
+            }
+        }
+    }
+
+
+    func testMainThreadCoreLocationManagerLocationGetsUpdatedOnLocationUpdates() {
         app.launchTunnel()
 
         app.coreLocationStubEnabled(true)
         app.coreLocationStubAuthorizationStatus(.authorizedAlways)
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
+
+        app.buttons["Get manager current location"].tap()
+        wait(withTimeout: 2) {
+            self.app.staticTexts["manager_location"].label == "nil"
+        }
+
+        app.coreLocationNotifyLocationUpdate([CLLocation(latitude: 44.0, longitude: 11.1)])
+
+        app.buttons["Get manager current location"].tap()
+        wait(withTimeout: 2) {
+            self.app.staticTexts["manager_location"].label == "44.0 \(11.1)"
+        }
+    }
+
+    func testBackgroundThreadCoreLocationManagerLocationGetsUpdatedOnLocationUpdates() {
+        app.launchTunnel()
+
+        app.coreLocationStubEnabled(true)
+        app.coreLocationStubAuthorizationStatus(.authorizedAlways)
+
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
 
         app.buttons["Get manager current location"].tap()
         wait(withTimeout: 2) {

--- a/Example/SBTUITestTunnel_TestsNoSwizzling/NoSwizzlingTests.swift
+++ b/Example/SBTUITestTunnel_TestsNoSwizzling/NoSwizzlingTests.swift
@@ -43,16 +43,25 @@ class NoSwizzlingTests: XCTestCase {
         waitForExpectations(timeout: 15.0, handler: nil)
     }
 
-    func testCoreLocationAuthorizationStatus() {
+    func testMainThreadCoreLocationAuthorizationStatus() {
         app.launchTunnel()
 
-        app.tables.cells["showCoreLocationViewController"].tap()
+        app.tables.cells["showMainThreadCoreLocationViewController"].tap()
         let statusPredicate = NSPredicate(format: "label == %@", "notDetermined")
         let statusElement = app.staticTexts["location_status"]
         expectation(for: statusPredicate, evaluatedWith: statusElement)
         waitForExpectations(timeout: 15.0, handler: nil)
     }
 
+    func testBackgroundThreadCoreLocationAuthorizationStatus() {
+        app.launchTunnel()
+
+        app.tables.cells["showBackgroundThreadCoreLocationViewController"].tap()
+        let statusPredicate = NSPredicate(format: "label == %@", "notDetermined")
+        let statusElement = app.staticTexts["location_status"]
+        expectation(for: statusPredicate, evaluatedWith: statusElement)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
 }
 
 class MyCustomApplication: XCUIApplication {

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -1344,6 +1344,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                 [invocation setSelector:@selector(locationManager:didChangeAuthorizationStatus:)];
                 [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
                 [invocation setArgument:&authorizationStatus atIndex:3];
+                [invocation retainArguments];
                 [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
             }
             #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
@@ -1358,7 +1359,8 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                         [invocation setTarget:locationManager.stubbedDelegate];
                         [invocation setSelector:@selector(locationManagerDidChangeAuthorization:)];
                         [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
-                        [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:locationManager waitUntilDone:NO];
+                        [invocation retainArguments];
+                        [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
                     }
                 }
             #endif
@@ -1386,6 +1388,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                     [invocation setTarget:locationManager.stubbedDelegate];
                     [invocation setSelector:@selector(locationManagerDidChangeAuthorization:)];
                     [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                    [invocation retainArguments];
                     [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
                 }
             }
@@ -1433,6 +1436,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                                 [invocation setSelector:@selector(locationManager:didUpdateLocations:)];
                                 [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
                                 [invocation setArgument:&locations atIndex:3];
+                                [invocation retainArguments];
                                 [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
                             }
                             
@@ -1470,6 +1474,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                 [invocation setSelector:@selector(locationManager:didFailWithError:)];
                 [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
                 [invocation setArgument:&error atIndex:3];
+                [invocation retainArguments];
                 [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
             }
         }

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -1334,16 +1334,31 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
         [CLLocationManager setStubbedAuthorizationStatus:authorizationStatus];
         for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
             if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManager:didChangeAuthorizationStatus:)]) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [locationManager.stubbedDelegate locationManager:locationManager didChangeAuthorizationStatus:authorizationStatus.intValue];
-                });
+                struct objc_method_description desc = protocol_getMethodDescription(@protocol(CLLocationManagerDelegate),
+                                                                                    @selector(locationManager:didChangeAuthorizationStatus:),
+                                                                                    NO,
+                                                                                    YES);
+                NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:desc.types];
+                NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                [invocation setTarget:locationManager.stubbedDelegate];
+                [invocation setSelector:@selector(locationManager:didChangeAuthorizationStatus:)];
+                [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                [invocation setArgument:&authorizationStatus atIndex:3];
+                [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
             }
             #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
                 if (@available(iOS 14.0, *)) {
                     if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManagerDidChangeAuthorization:)]) {
-                        dispatch_async(dispatch_get_main_queue(), ^{
-                            [locationManager.stubbedDelegate locationManagerDidChangeAuthorization:locationManager];
-                        });
+                        struct objc_method_description desc = protocol_getMethodDescription(@protocol(CLLocationManagerDelegate),
+                                                                                            @selector(locationManagerDidChangeAuthorization:),
+                                                                                            NO,
+                                                                                            YES);
+                        NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:desc.types];
+                        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                        [invocation setTarget:locationManager.stubbedDelegate];
+                        [invocation setSelector:@selector(locationManagerDidChangeAuthorization:)];
+                        [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                        [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:locationManager waitUntilDone:NO];
                     }
                 }
             #endif
@@ -1362,9 +1377,16 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
             [CLLocationManager setStubbedAccuracyAuthorization:accuracyAuthorization];
             for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
                 if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManagerDidChangeAuthorization:)]) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [locationManager.stubbedDelegate locationManagerDidChangeAuthorization:locationManager];
-                    });
+                    struct objc_method_description desc = protocol_getMethodDescription(@protocol(CLLocationManagerDelegate),
+                                                                                        @selector(locationManagerDidChangeAuthorization:),
+                                                                                        NO,
+                                                                                        YES);
+                    NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:desc.types];
+                    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                    [invocation setTarget:locationManager.stubbedDelegate];
+                    [invocation setSelector:@selector(locationManagerDidChangeAuthorization:)];
+                    [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                    [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
                 }
             }
         #endif
@@ -1401,9 +1423,17 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                         case kCLAuthorizationStatusAuthorizedAlways:
                         case kCLAuthorizationStatusAuthorizedWhenInUse: {
                             if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {
-                                dispatch_async(dispatch_get_main_queue(), ^{
-                                    [locationManager.stubbedDelegate locationManager:locationManager didUpdateLocations:locations];
-                                });
+                                struct objc_method_description desc = protocol_getMethodDescription(@protocol(CLLocationManagerDelegate),
+                                                                                                    @selector(locationManager:didUpdateLocations:),
+                                                                                                    NO,
+                                                                                                    YES);
+                                NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:desc.types];
+                                NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                                [invocation setTarget:locationManager.stubbedDelegate];
+                                [invocation setSelector:@selector(locationManager:didUpdateLocations:)];
+                                [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                                [invocation setArgument:&locations atIndex:3];
+                                [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
                             }
                             
                             break;
@@ -1430,9 +1460,17 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 
         for (CLLocationManager *locationManager in self.coreLocationActiveManagers.keyEnumerator.allObjects) {
             if ([locationManager.stubbedDelegate respondsToSelector:@selector(locationManager:didFailWithError:)]) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [locationManager.stubbedDelegate locationManager:locationManager didFailWithError:error];
-                });
+                struct objc_method_description desc = protocol_getMethodDescription(@protocol(CLLocationManagerDelegate),
+                                                                                    @selector(locationManager:didFailWithError:),
+                                                                                    NO,
+                                                                                    YES);
+                NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:desc.types];
+                NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                [invocation setTarget:locationManager.stubbedDelegate];
+                [invocation setSelector:@selector(locationManager:didFailWithError:)];
+                [invocation setArgument:(void * _Nonnull)&(locationManager) atIndex:2];
+                [invocation setArgument:&error atIndex:3];
+                [invocation performSelector:@selector(invoke) onThread:locationManager.swz_creationThread withObject:nil waitUntilDone:NO];
             }
         }
     #endif

--- a/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.h
+++ b/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.h
@@ -28,6 +28,7 @@
 
 - (id<CLLocationManagerDelegate>)stubbedDelegate;
 - (CLLocation *)location;
+- (NSThread *)swz_creationThread;
 
 @end
 


### PR DESCRIPTION
Makes CLLocationManager to invoke all delegate calls on the same thread where the CLLocationManager was created, following behaviour of the CLLocationManager without swizzling. Adds tests for CoreLocation for Main and Background threads