### PR TITLE
Fix scroll with opened keyboard

### DIFF
--- a/Example/SBTUITestTunnel/Main.storyboard
+++ b/Example/SBTUITestTunnel/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24093.9" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DUh-KF-iax">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DUh-KF-iax">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24057"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -220,8 +220,25 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="crashCell" id="K1T-Ra-IGi" userLabel="crashCell">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="extension7Cell" id="lpQ-4I-Kii" userLabel="extension7Cell">
                                 <rect key="frame" x="0.0" y="490" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lpQ-4I-Kii" id="TCe-RN-dL3">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="XCUITest extension - CollectionView (with Keyboard)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3D-oE-jCp">
+                                            <rect key="frame" x="8" y="11" width="367" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="crashCell" id="K1T-Ra-IGi" userLabel="crashCell">
+                                <rect key="frame" x="0.0" y="534" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="K1T-Ra-IGi" id="f1M-hZ-1MC">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -514,7 +531,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dis-co-nnc">
-                                <rect key="frame" x="16" y="117" width="103" height="35"/>
+                                <rect key="frame" x="16" y="117" width="110.5" height="35"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Disconnect"/>
                                 <connections>

--- a/Example/SBTUITestTunnel/SBTExtensionCollectionViewWithKeyboardViewController.swift
+++ b/Example/SBTUITestTunnel/SBTExtensionCollectionViewWithKeyboardViewController.swift
@@ -1,0 +1,116 @@
+// swiftlint:disable implicit_return
+// swiftformat:disable redundantReturn
+
+import UIKit
+
+class SBTExtensionCollectionViewWithKeyboardViewController: UIViewController {
+    private let flowLayout: UICollectionViewFlowLayout
+    private let collectionView: UICollectionView
+    private let textField = UITextField()
+
+    init() {
+        flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .vertical
+
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .green
+        collectionView.contentInsetAdjustmentBehavior = .always
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        collectionView.register(KeyboardTestCell.self, forCellWithReuseIdentifier: "cell")
+        collectionView.accessibilityIdentifier = "scrollViewWithKeyboard"
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .blue
+
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.borderStyle = .roundedRect
+        textField.placeholder = "Tap to show keyboard"
+        textField.accessibilityIdentifier = "keyboardTextField"
+        view.addSubview(textField)
+
+        view.addSubview(collectionView)
+
+        NSLayoutConstraint.activate([
+            textField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            textField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            textField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+
+            collectionView.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: 8),
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+        ])
+
+        collectionView.dataSource = self
+        collectionView.delegate = self
+    }
+}
+
+extension SBTExtensionCollectionViewWithKeyboardViewController: UICollectionViewDataSource {
+    func numberOfSections(in _: UICollectionView) -> Int {
+        return 1
+    }
+
+    func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
+        return 100
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as? KeyboardTestCell {
+            cell.configure(with: "\(indexPath.item)")
+            return cell
+        }
+        return UICollectionViewCell()
+    }
+}
+
+extension SBTExtensionCollectionViewWithKeyboardViewController: UICollectionViewDelegateFlowLayout {
+    public func collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt _: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: 100)
+    }
+}
+
+private final class KeyboardTestCell: UICollectionViewCell {
+    let label = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    func commonInit() {
+        contentView.backgroundColor = .red
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        contentView.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: contentView.topAnchor),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+    }
+
+    public func configure(with text: String?) {
+        label.text = text
+        accessibilityIdentifier = text
+    }
+}

--- a/Example/SBTUITestTunnel/SBTTableViewController.swift
+++ b/Example/SBTUITestTunnel/SBTTableViewController.swift
@@ -37,6 +37,7 @@ class Extension3Test: BaseTest {}
 class Extension4Test: BaseTest {}
 class Extension5Test: BaseTest {}
 class Extension6Test: BaseTest {}
+class Extension7Test: BaseTest {}
 class CrashTest: BaseTest {}
 
 class SBTTableViewController: UITableViewController {
@@ -65,6 +66,7 @@ class SBTTableViewController: UITableViewController {
                                         Extension4Test(testSelector: #selector(showCoreLocationViewController)),
                                         Extension5Test(testSelector: #selector(showExtensionCollectionViewVertical)),
                                         Extension6Test(testSelector: #selector(showExtensionCollectionViewHorizontal)),
+                                        Extension7Test(testSelector: #selector(showExtensionCollectionViewWithKeyboard)),
                                         CrashTest(testSelector: #selector(crashApp))]
 
     override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
@@ -92,6 +94,8 @@ class SBTTableViewController: UITableViewController {
             tableView.dequeueReusableCell(withIdentifier: "extension5Cell", for: indexPath)
         } else if testList[indexPath.row] is Extension6Test {
             tableView.dequeueReusableCell(withIdentifier: "extension6Cell", for: indexPath)
+        } else if testList[indexPath.row] is Extension7Test {
+            tableView.dequeueReusableCell(withIdentifier: "extension7Cell", for: indexPath)
         } else if testList[indexPath.row] is CrashTest {
             tableView.dequeueReusableCell(withIdentifier: "crashCell", for: indexPath)
         } else {
@@ -448,6 +452,11 @@ extension SBTTableViewController {
 
     @objc func showExtensionCollectionViewHorizontal() {
         let targetViewController = SBTExtensionCollectionViewController(scrollDirection: .horizontal)
+        navigationController?.pushViewController(targetViewController, animated: true)
+    }
+    
+    @objc func showExtensionCollectionViewWithKeyboard() {
+        let targetViewController = SBTExtensionCollectionViewWithKeyboardViewController()
         navigationController?.pushViewController(targetViewController, animated: true)
     }
 }

--- a/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
+++ b/Example/SBTUITestTunnel_Tests/MiscellaneousTests.swift
@@ -226,6 +226,42 @@ class MiscellaneousTests: XCTestCase {
         XCTAssert(app.buttons["Button"].isHittable)
     }
 
+    func testScrollViewScrollToElementWithKeyboardVisible() {
+        app.launchTunnel()
+
+        app.cells["showExtensionCollectionViewWithKeyboard"].tap()
+
+        let textField = app.textFields["keyboardTextField"]
+        wait { textField.isHittable }
+        textField.tap()
+
+        wait { self.app.keyboards.count > 0 }
+
+        XCTAssertFalse(app.staticTexts["50"].isHittable)
+
+        XCTAssertTrue(app.scrollScrollView(withIdentifier: "scrollViewWithKeyboard", toElementWithIdentifier: "50", animated: true))
+
+        let element = app.staticTexts["50"]
+        XCTAssert(element.isHittable)
+
+        // Verify the element is centered in the visible area (between collection view top and keyboard top)
+        let collectionView = app.collectionViews["scrollViewWithKeyboard"]
+        let keyboard = app.keyboards.firstMatch
+        let visibleTop = collectionView.frame.minY
+        let visibleBottom = keyboard.frame.minY
+        let visibleMidY = (visibleTop + visibleBottom) / 2.0
+        
+        let elementMidY = element.frame.midY
+
+        let tolerance = element.frame.height / 2.0 + 50.0
+        XCTAssertEqual(
+            elementMidY,
+            visibleMidY,
+            accuracy: tolerance,
+            "Element midY (\(elementMidY)) should be near visible area midY (\(visibleMidY)), difference: \(abs(elementMidY - visibleMidY)), tolerance: \(tolerance)"
+        )
+    }
+
     func testScrollViewScrollToOffset() {
         app.launchTunnel()
 

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -86,6 +86,7 @@ void repeating_dispatch_after(int64_t delay, dispatch_queue_t queue, BOOL (^bloc
 @property (nonatomic, strong) NSMapTable<CLLocationManager *, id<CLLocationManagerDelegate>> *coreLocationActiveManagers;
 @property (nonatomic, strong) NSMutableString *coreLocationStubbedServiceStatus;
 @property (nonatomic, strong) NSMutableString *notificationCenterStubbedAuthorizationStatus;
+@property (nonatomic, assign) CGRect keyboardFrameInScreenCoordinates;
 
 @property (nonatomic, strong) DTXIPCConnection* ipcConnection;
 @property (nonatomic, strong) id<SBTIPCTunnel> ipcProxy;
@@ -109,6 +110,9 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
         sharedInstance.coreLocationStubbedServiceStatus = [NSMutableString string];
         sharedInstance.notificationCenterStubbedAuthorizationStatus = [NSMutableString stringWithString:[@(UNAuthorizationStatusAuthorized) stringValue]];
         sharedInstance.webSocketServers = [NSMutableDictionary dictionary];
+        sharedInstance.keyboardFrameInScreenCoordinates = CGRectNull;
+
+        [sharedInstance startObservingKeyboardNotifications];
 
         [sharedInstance reset];
     });
@@ -865,6 +869,74 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
     return @{ SBTUITunnelResponseResultKey: @"YES" };
 }
 
+- (void)startObservingKeyboardNotifications
+{
+    NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
+
+    [notificationCenter addObserver:self selector:@selector(handleKeyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
+    [notificationCenter addObserver:self selector:@selector(handleKeyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+}
+
+- (void)handleKeyboardWillChangeFrame:(NSNotification *)notification
+{
+    CGRect keyboardFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    self.keyboardFrameInScreenCoordinates = keyboardFrame;
+}
+
+- (void)handleKeyboardWillHide:(NSNotification *)notification
+{
+    self.keyboardFrameInScreenCoordinates = CGRectNull;
+}
+
+- (BOOL)isKeyboardVisible
+{
+    return !CGRectIsNull(self.keyboardFrameInScreenCoordinates) && !CGRectIsEmpty(self.keyboardFrameInScreenCoordinates);
+}
+
+- (CGFloat)maxContentOffsetForScrollView:(UIScrollView *)scrollView direction:(SBTUITestTunnelScrollDirection)direction
+{
+    UIEdgeInsets insets = scrollView.adjustedContentInset;
+
+    if (direction == SBTUITestTunnelScrollDirectionHorizontal) {
+        CGFloat maxOffset = scrollView.contentSize.width - scrollView.bounds.size.width + insets.right;
+        return MAX(-insets.left, maxOffset);
+    }
+
+    CGFloat maxOffset = scrollView.contentSize.height - scrollView.bounds.size.height + insets.bottom;
+    return MAX(-insets.top, maxOffset);
+}
+
+- (CGRect)visibleUnobscuredFrameInWindowForScrollView:(UIScrollView *)scrollView
+{
+    UIWindow *window = scrollView.window ?: UIApplication.sharedApplication.keyWindow;
+    if (window == nil) {
+        return CGRectZero;
+    }
+
+    CGRect visibleFrame = [scrollView convertRect:scrollView.bounds toView:window];
+    visibleFrame = CGRectIntersection(window.bounds, visibleFrame);
+
+    if (CGRectIsNull(visibleFrame) || CGRectIsEmpty(visibleFrame)) {
+        return CGRectZero;
+    }
+
+    if ([self isKeyboardVisible]) {
+        CGRect keyboardFrame = [window convertRect:self.keyboardFrameInScreenCoordinates fromWindow:nil];
+        CGRect overlap = CGRectIntersection(visibleFrame, keyboardFrame);
+        if (!CGRectIsNull(overlap) && !CGRectIsEmpty(overlap)) {
+            if (CGRectGetMinY(overlap) > CGRectGetMinY(visibleFrame)) {
+                visibleFrame.size.height = MAX(0.0, CGRectGetMinY(overlap) - CGRectGetMinY(visibleFrame));
+            } else {
+                CGFloat visibleMaxY = CGRectGetMaxY(visibleFrame);
+                visibleFrame.origin.y = CGRectGetMaxY(overlap);
+                visibleFrame.size.height = MAX(0.0, visibleMaxY - CGRectGetMinY(visibleFrame));
+            }
+        }
+    }
+
+    return visibleFrame;
+}
+
 #pragma mark - XCUITest scroll extensions
 
 - (BOOL)scrollElementWithIdentifier:(NSString *)elementIdentifier elementClass:(Class)elementClass toRow:(NSInteger)elementRow numberOfSections:(NSInteger (^)(UIView *))sectionsDataSource numberOfRows:(NSInteger (^)(UIView *, NSInteger))rowsDataSource scrollDelegate:(void (^)(UIView *, NSIndexPath *))scrollDelegate;
@@ -969,6 +1041,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                 BOOL expectedIdentifier = [view.accessibilityIdentifier isEqualToString:elementIdentifier] || [view.accessibilityLabel isEqualToString:elementIdentifier];
                 if (expectedIdentifier) {
                     UIScrollView *scrollView = (UIScrollView *)view;
+                    SBTUITestTunnelScrollDirection scrollDirection = scrollView.suggestedScrollDirection;
 
                     while (!result) {
                         NSArray *allScrollViewViews = [scrollView allSubviews];
@@ -976,16 +1049,33 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                             BOOL expectedTargetIdentifier = [scrollViewView.accessibilityIdentifier isEqualToString:targetElementIdentifier] || [scrollViewView.accessibilityLabel isEqualToString:targetElementIdentifier];
                             
                             if (expectedTargetIdentifier) {
-                                CGRect frameInScrollView = [scrollViewView convertRect:scrollViewView.bounds toView:scrollView];
-                                CGFloat targetContentOffsetX = 0.0;
-                                CGFloat targetContentOffsetY = 0.0;
+                                CGFloat targetContentOffsetX = scrollView.contentOffset.x;
+                                CGFloat targetContentOffsetY = scrollView.contentOffset.y;
 
-                                if (scrollView.suggestedScrollDirection == SBTUITestTunnelScrollDirectionVertical) {
-                                    targetContentOffsetX = scrollView.contentOffset.x;
-                                    targetContentOffsetY = MAX(0.0, frameInScrollView.origin.y - view.bounds.size.height / 2);
-                                } else if (scrollView.suggestedScrollDirection == SBTUITestTunnelScrollDirectionHorizontal) {
-                                    targetContentOffsetX = MAX(0.0, frameInScrollView.origin.x - view.bounds.size.width / 2);
-                                    targetContentOffsetY = scrollView.contentOffset.y;
+                                BOOL keyboardVisible = [self isKeyboardVisible];
+                                BOOL isVertical = (scrollDirection == SBTUITestTunnelScrollDirectionVertical);
+
+                                if (keyboardVisible) {
+                                    UIWindow *window = scrollView.window ?: UIApplication.sharedApplication.keyWindow;
+                                    CGRect visibleFrameInWindow = [self visibleUnobscuredFrameInWindowForScrollView:scrollView];
+                                    CGRect targetFrameInWindow = [scrollViewView convertRect:scrollViewView.bounds toView:window];
+                                    UIEdgeInsets insets = scrollView.adjustedContentInset;
+                                    CGFloat maxOffset = [self maxContentOffsetForScrollView:scrollView direction:scrollDirection];
+
+                                    if (isVertical) {
+                                        targetContentOffsetY = scrollView.contentOffset.y + (CGRectGetMidY(targetFrameInWindow) - CGRectGetMidY(visibleFrameInWindow));
+                                        targetContentOffsetY = MIN(maxOffset, MAX(-insets.top, targetContentOffsetY));
+                                    } else {
+                                        targetContentOffsetX = scrollView.contentOffset.x + (CGRectGetMidX(targetFrameInWindow) - CGRectGetMidX(visibleFrameInWindow));
+                                        targetContentOffsetX = MIN(maxOffset, MAX(-insets.left, targetContentOffsetX));
+                                    }
+                                } else {
+                                    CGRect frameInScrollView = [scrollViewView convertRect:scrollViewView.bounds toView:scrollView];
+                                    if (isVertical) {
+                                        targetContentOffsetY = MAX(0.0, frameInScrollView.origin.y - scrollView.bounds.size.height / 2.0);
+                                    } else {
+                                        targetContentOffsetX = MAX(0.0, frameInScrollView.origin.x - scrollView.bounds.size.width / 2.0);
+                                    }
                                 }
 
                                 [scrollView setContentOffset:CGPointMake(targetContentOffsetX, targetContentOffsetY) animated:animated];
@@ -1001,7 +1091,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                         if (result) {
                             break;
                         } else {
-                            if (scrollView.suggestedScrollDirection == SBTUITestTunnelScrollDirectionVertical) {
+                            if (scrollDirection == SBTUITestTunnelScrollDirectionVertical) {
                                 CGFloat maxOffset = MAX(0, floor(scrollView.contentSize.height - scrollView.bounds.size.height / 2.0));
                                 if (scrollView.contentOffset.y < maxOffset)  {
                                     CGFloat targetContentOffsetY = MIN(maxOffset, ceil(scrollView.contentOffset.y + scrollView.frame.size.height));
@@ -1014,7 +1104,7 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
                                 } else {
                                     break;
                                 }
-                            } else if (scrollView.suggestedScrollDirection == SBTUITestTunnelScrollDirectionHorizontal) {
+                            } else if (scrollDirection == SBTUITestTunnelScrollDirectionHorizontal) {
                                 CGFloat maxOffset = MAX(0, floor(scrollView.contentSize.width - scrollView.bounds.size.width / 2.0));
                                 if (scrollView.contentOffset.x < maxOffset)  {
                                     CGFloat targetContentOffsetX = MIN(maxOffset, ceil(scrollView.contentOffset.x + scrollView.frame.size.width));


### PR DESCRIPTION
When scrolling to an element with the keyboard visible, center the element within the unobscured viewport rather than the full scrollview frame. Use adjustedContentInset to properly calculate visible bounds.