### PR TITLE
Improves the reliability of IPC connections

### DIFF
--- a/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
+++ b/Sources/SBTUITestTunnelClient/SBTUITestTunnelClient.m
@@ -79,6 +79,10 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
     self.connected = NO;
     self.connectionPort = 0;
     self.connectionTimeout = SBTUITunneledApplicationDefaultTimeout;
+
+    [self.ipcConnection invalidate];
+    self.ipcConnection = nil;
+    self.ipcProxy = nil;
 }
 
 - (void)shutDownWithError:(NSError *)error
@@ -159,20 +163,24 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
         self.application.launchEnvironment = launchEnvironment;
         
         __weak typeof(self)weakSelf = self;
-        // Start polling the server with the choosen port
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [weakSelf waitForConnection];
-            NSLog(@"[SBTUITestTunnel] HTTP tunnel did connect after, %fs", CFAbsoluteTimeGetCurrent() - self.launchStart);
-            
+
+            if (!weakSelf || weakSelf.connectionPort == 0) {
+                return;
+            }
+
+            NSLog(@"[SBTUITestTunnel] HTTP tunnel did connect after, %fs", CFAbsoluteTimeGetCurrent() - weakSelf.launchStart);
+
             dispatch_async(dispatch_get_main_queue(), ^{
                 weakSelf.connected = YES;
                 if (weakSelf.startupBlock) {
                     weakSelf.startupBlock();
                     NSLog(@"[SBTUITestTunnel] Did perform startupBlock");
                 }
-                
+
                 NSAssert([NSThread isMainThread], @"We synch on main thread");
-                weakSelf.startupCompleted = [[self sendSynchronousRequestWithPath:SBTUITunneledApplicationCommandStartupCommandsCompleted params:@{}] isEqualToString:@"YES"];
+                weakSelf.startupCompleted = [[weakSelf sendSynchronousRequestWithPath:SBTUITunneledApplicationCommandStartupCommandsCompleted params:@{}] isEqualToString:@"YES"];
             });
         });
     }
@@ -1131,8 +1139,10 @@ static NSTimeInterval SBTUITunneledApplicationDefaultTimeout = 30.0;
         dispatch_semaphore_signal(synchRequestSemaphore);
     }] resume];
     
-    if (dispatch_semaphore_wait(synchRequestSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SBTUITunneledApplicationDefaultTimeout * NSEC_PER_SEC))) != 0) {}
-    
+    if (dispatch_semaphore_wait(synchRequestSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SBTUITunneledApplicationDefaultTimeout * NSEC_PER_SEC))) != 0) {
+        NSLog(@"[SBTUITestTunnel] HTTP request timeout after %ds for %@", (int)SBTUITunneledApplicationDefaultTimeout, request.URL);
+    }
+
     return responseId;
 }
 

--- a/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection-Private.h
+++ b/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection-Private.h
@@ -10,7 +10,8 @@
 
 @protocol _DTXIPCImpl <NSObject>
 
-- (oneway void)_slaveDidConnectWithName:(NSString*)slaveServiceName;
+// Intentionally synchronous (not oneway): caller must block until master sets _otherConnection.
+- (void)_slaveDidConnectWithName:(NSString*)slaveServiceName;
 - (oneway void)_invokeFromRemote:(NSDictionary*)serializedInvocation;
 - (oneway void)_invokeRemoteBlock:(NSDictionary*)serializedBlock;
 - (oneway void)_cleanupRemoteBlock:(NSString*)identifier;

--- a/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.m
+++ b/Sources/SBTUITestTunnelCommon/DetoxIPC/DTXIPCConnection.m
@@ -192,13 +192,22 @@ static dispatch_queue_t _connectionQueue;
 	BOOL _resumed;
 }
 
-- (void)_runQueue
+- (void)_startConnectionSignalingReady:(dispatch_semaphore_t)readySemaphore
 {
 	_runLoop = NSRunLoop.currentRunLoop;
-	
-	[_connection run];
-	
 	_resumed = YES;
+
+	[_connection addRunLoop:_runLoop];
+
+	if (readySemaphore) {
+		CFRunLoopRef rl = CFRunLoopGetCurrent();
+		CFRunLoopPerformBlock(rl, kCFRunLoopDefaultMode, ^{
+			dispatch_semaphore_signal(readySemaphore);
+		});
+		CFRunLoopWakeUp(rl);
+	}
+
+	CFRunLoopRun();
 }
 
 - (BOOL)_commonInit
@@ -282,12 +291,20 @@ static dispatch_queue_t _connectionQueue;
 	{
 		return;
 	}
-	
+
 	NSAssert(_exportedObject != nil || _remoteObjectInterface != nil, @"An exported object or a remote object interface must be set before resuming the connection.");
-	
+
+	dispatch_semaphore_t readySemaphore = dispatch_semaphore_create(0);
 	dispatch_async(_dispatchQueue, ^{
-		[self _runQueue];
+		[self _startConnectionSignalingReady:readySemaphore];
 	});
+	// Wait for the connection's run loop to be actively processing messages.
+	// This prevents a race where the remote endpoint connects before
+	// the run loop is ready to handle incoming Mach port messages.
+	long waitResult = dispatch_semaphore_wait(readySemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)));
+	if (waitResult != 0) {
+		NSLog(@"[DTXIPCConnection] WARNING: Timed out waiting for connection run loop to start for service '%@'", _serviceName);
+	}
 }
 
 - (void)invalidate
@@ -330,7 +347,7 @@ static dispatch_queue_t _connectionQueue;
 
 #pragma mark _DTXIPCImpl
 
-- (oneway void)_slaveDidConnectWithName:(NSString*)slaveServiceName
+- (void)_slaveDidConnectWithName:(NSString*)slaveServiceName
 {
     dispatch_sync(_otherConnectionQueue, ^{
         _otherConnection = [NSConnection connectionWithRegisteredName:slaveServiceName host:nil];

--- a/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
+++ b/Sources/SBTUITestTunnelServer/SBTUITestTunnelServer.m
@@ -263,8 +263,11 @@ static NSTimeInterval SBTUITunneledServerDefaultTimeout = 60.0;
 
             dispatch_semaphore_signal(sem);
         });
-
-        if (dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SBTUITunneledServerDefaultTimeout * NSEC_PER_SEC))) != 0) {}
+        
+        if (dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SBTUITunneledServerDefaultTimeout * NSEC_PER_SEC))) != 0) {
+            NSString *command = [request.path stringByReplacingOccurrencesOfString:@"/" withString:@""];
+            NSLog(@"[SBTUITestTunnel] Server command queue timeout after %ds for command '%@'", (int)SBTUITunneledServerDefaultTimeout, command);
+        }
         return ret;
     }];
 


### PR DESCRIPTION
This PR improves a bit the reliability of IPC connections and hardens error handling in the HTTP tunnel. 

Issues solved:
1. The IPC tunnel had a race condition where the remote endpoint could connect before the local run loop was ready to handle incoming Mach port messages. `resume` dispatched `_runQueue` asynchronously and returned immediately. Under load, the slave's `_slaveDidConnectWithName:` call could arrive before `[_connection run]` had executed, causing intermittent connection failures.

2. If `waitForConnection` timed out, `shutDownWithErrorMessage:` was called but returned normally. Execution in the `dispatch_after` block continued, setting `connected = YES` and firing the startup block on an already shut-down client.

3. HTTP request timeouts in the client and server command queue timeouts were silently swallowed with empty if blocks, making timeout-related failures invisible in logs.