### PR TITLE
Fix authStatus value sent to CLLocationManager delegate

### DIFF
--- a/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
+++ b/Sources/SBTUITestTunnelServer/private/CLLocationManager+Swizzles.m
@@ -160,7 +160,7 @@ static char const * const swz_creationThreadKey = "swz_creationThreadKey";
 - (void)swz_invokeOldDelegate:(id<CLLocationManagerDelegate>)delegate {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [delegate locationManager:self didChangeAuthorizationStatus:self.swz_authorizationStatus];
+    [delegate locationManager:self didChangeAuthorizationStatus:self.authorizationStatus];
 #pragma GCC diagnostic pop
 }
 


### PR DESCRIPTION
The value sent to CLLocationManager delegate is now being taken from stubbed value (set in setStubbedAuthorizationStatus) instead of actual device state.

Fixes problem when stubbed value diverges from device state value for clients using locationManager:didChangeAuthorizationStatus: delegate method.